### PR TITLE
Adding Acknowledgements to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,12 @@ Terraform `thousandeyes` Provider
 Maintainers
 -----------
 
-This provider plugin is community maintained
+This provider plugin is maintained by the ThousandEyes engineering team and accepts community contributions.
+
+Acknowledgements
+----------------
+
+ThousandEyes would like to thank William Fleming, John Dyer, and Joshua Blanchard for their contribution and community maintenance of this project.
 
 Requirements
 ------------


### PR DESCRIPTION
Our GH Org policy does not allow external collaborators in a repo, and we wanted to publicly acknowledge the extensive work by William Fleming, John Dyer, and Joshua Blanchard on the provider and SDK prior to ThousandEyes assuming maintenance of the project.