### PR TITLE
docs: update README

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,6 +23,8 @@ builds:
         goarch: '386'
       - goos: windows
         goarch: arm64
+      - goos: windows
+        goarch: arm
     binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
   - format: zip

--- a/README.md
+++ b/README.md
@@ -1,47 +1,14 @@
-Terraform `thousandeyes` Provider
-=========================
+# Terraform Provider for ThousandEyes [![GitHub tag (latest SemVer)](https://img.shields.io/github/v/tag/thousandeyes/terraform-provider-thousandeyes?label=release)](https://github.com/thousandeyes/terraform-provider-thousandeyes/releases) [![license](https://img.shields.io/github/license/thousandeyes/terraform-provider-thousandeyes.svg)]()
 
-- Website: [https://registry.terraform.io/providers/thousandeyes/thousandeyes/latest](https://registry.terraform.io/providers/thousandeyes/thousandeyes/latest)
-- [![Gitter chat](https://badges.gitter.im/hashicorp-terraform/Lobby.png)](https://gitter.im/hashicorp-terraform/Lobby)
-- Mailing list: [Google Groups](http://groups.google.com/group/terraform-tool)
+The Terraform provider for ThousandEyes allows you to manage resources in [ThousandEyes](https://www.thousandeyes.com/).
 
-<img src="https://cdn.rawgit.com/hashicorp/terraform-website/master/content/source/assets/images/logo-hashicorp.svg" width="600px">
-
-Maintainers
------------
-
-This provider plugin is maintained by the ThousandEyes engineering team and accepts community contributions.
-
-Acknowledgements
-----------------
-
-ThousandEyes would like to thank William Fleming, John Dyer, and Joshua Blanchard for their contribution and community maintenance of this project.
-
-Requirements
-------------
+## Requirements
 
 - [Terraform](https://www.terraform.io/downloads.html) 0.12.x
-- [Go](https://golang.org/doc/install) 1.16 (to build the provider plugin)
+- [Go](https://golang.org/doc/install) 1.17 (to build the provider plugin)
 
-Building The Provider
----------------------
-
-Clone repository to: `$GOPATH/src/github.com/thousandeyes/terraform-provider-thousandeyes`
-
-```sh
-$ git clone git@github.com:thousandeyes/terraform-provider-thousandeyes $GOPATH/src/github.com/thousandeyes/terraform-provider-thousandeyes
-```
-
-Enter the provider directory and build the provider
-
-```sh
-$ cd $GOPATH/src/github.com/thousandeyes/terraform-provider-thousandeyes
-$ make build
-```
-
-Using the provider
-----------------------
-The provider is now on the terraform registry to pull it as a dependency do the following and run `terraform init`
+## Usage
+The provider is on the Terraform registry. To use it, add the following code and run `terraform init`:
 
 ```hcl
 terraform {
@@ -53,81 +20,76 @@ terraform {
 }
 ```
 
-If you're building the provider, follow the instructions to [install it as a plugin.](https://www.terraform.io/docs/plugins/basics.html#installing-a-plugin) After placing it into your plugins directory,  run `terraform init` to initialize it.
-
 ### Setting up provider
-
 ```hcl
-
 provider "thousandeyes" {
   token = "xxxxxx-xxxx-xxxx-xxxx-xxxxxxxxx"
 }
 
 ```
 
-The provider requires that the token be set, the token may instead be passed via the environment variable `TE_TOKEN`.
+The provider requires a token. The token can be set on the `token` variable, as shown in the example, or it may instead be passed via the `TE_TOKEN` environment variable.
 
 The provider also supports the following optional settings:
 
 - `account_group_id` may be set to distinguish between affected account groups, if your ThousandEyes account supports more than one.  This may instead be set by the environment variable `TE_AID`.
 - `timeout` may be set to specify the number of seconds to wait for responses from the ThousandEyes endpoints.  This may instead be set by the environment variable `TE_TIMEOUT`.  If this is unset or set to `0`, then the thousandeyes-sdk-go library will use its default settings.
 
-### HTTP Test
+### Examples
+Example of an HTTP test:
 
 ```hcl
-
-data "thousandeyes_agent" "test_agent" {
-  name  = "na-sjc-2-te [VS01]"
+data "thousandeyes_agent" "arg_cordoba" {
+  agent_name = "Cordoba, Argentina"
 }
 
-resource "thousandeyes_http_server" "google_http_test" {
-  name = "google test"
-  interval = 120
-  url = "https://google.com"
-  agents {
-      agent_id = data.thousandeyes_agent.test_agent.agent_id
-  }
-  agents {
+resource "thousandeyes_http_server" "www_thousandeyes_http_test" {
+  test_name      = "Example HTTP test set from Terraform provider"
+  interval       = 120
+  alerts_enabled = false
 
-      agent_id = 12345
+  url = "https://www.thousandeyes.com"
+
+  agents {
+    agent_id = data.thousandeyes_agent.arg_cordoba.agent_id
   }
 }
 ```
 
-### Agent to Server
+### Supported tests
+- [X] agent-to-agent
+- [X] agent-to-server
+- [X] alert-rule
+- [X] bgp
+- [X] dnssec
+- [X] dns-server
+- [X] dns-trace
+- [X] ftp-server
+- [X] http-server
+- [X] page-load
+- [X] sip-server
+- [X] voice-call
+- [X] voice (RTP stream)
+- [X] web-transactions
 
-```hcl
-data "thousandeyes_agent" "test_agent_example" {
-  name  = "na-sjc-2-te [VS01]"
-}
+## Building The Provider
+Clone repository to: `$GOPATH/src/github.com/thousandeyes/terraform-provider-thousandeyes`
 
-resource "thousandeyes_agent_to_server" "agent_test_example" {
-  name = "my agent test"
-  interval = 120
-  server = "8.8.8.8"
-  agents {
-      agent_id = data.thousandeyes_agent.test_agent_example.agent_id
-  }
-
-}
+```sh
+$ git clone git@github.com:thousandeyes/terraform-provider-thousandeyes $GOPATH/src/github.com/thousandeyes/terraform-provider-thousandeyes
 ```
 
-Supported tests right now:
+Enter the provider directory and build the provider:
 
-- [x] http-server
-- [x] page-load
-- [x] web-transactions
-- [x] agent-to-server
-- [x] agent-to-agent
-- [x] bgp
-- [ ] transactions
-- [x] ftp-server
-- [x] dns-trace
-- [x] dns-server
-- [x] dns-dnssec
-- [ ] dnsp-domain
-- [ ] dnsp-server
-- [x] sip-server
-- [x] voice (RTP Stream)
-- [x] voice-call
+```sh
+$ cd $GOPATH/src/github.com/thousandeyes/terraform-provider-thousandeyes
+$ make build
+```
 
+Follow the instructions to [install it as a plugin](https://www.terraform.io/docs/plugins/basics.html#installing-a-plugin). After placing it into your plugins directory,  run `terraform init` to initialize it.
+
+## Maintainers
+This provider plugin is maintained by the ThousandEyes engineering team and accepts community contributions.
+
+## Acknowledgements
+ThousandEyes would like to thank William Fleming, John Dyer, and Joshua Blanchard for their contribution and community maintenance of this project.


### PR DESCRIPTION
- Fix Terraform logo link
- Update HTTP example. More examples to come in a dedicated examples/ directory.
- Drop gitter badge
- Drop link to Google Groups
- Drop dnsq tests, as they are no longer supported
- Add badges for sem version and license
- Change order of sections

Note that we will have a dedicated effort to update the documentation, add additional examples, and structure the documentation files it in a better way.

Edit: piggy-backing a commit to disable Windows ARM builds, as they're holding the pipeline. We can bring them back if there's a demand for them.