### PR TITLE
ci: fix testing on pull requests 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,12 +10,11 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.14
+          go-version: 1.17
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v1
+        uses: goreleaser/goreleaser-action@v3
         with:
           version: latest
           args: build --snapshot
-          key: ${{ secrets.YOUR_PRIVATE_KEY }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,13 +18,6 @@ builds:
       - amd64
       - arm
       - arm64
-    ignore:
-      - goos: darwin
-        goarch: '386'
-      - goos: windows
-        goarch: arm64
-      - goos: windows
-        goarch: arm
     binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
   - format: zip


### PR DESCRIPTION
- restore windows builds
- use go 1.17 on test.yaml
- drop darwin ignore on 386. We don't build that arch.