### PR TITLE
fix: use TypeSet for Agents

### DIFF
--- a/thousandeyes/schemas.go
+++ b/thousandeyes/schemas.go
@@ -44,7 +44,7 @@ var schemas = map[string]*schema.Schema{
 		},
 	},
 	"agents": {
-		Type:        schema.TypeList,
+		Type:        schema.TypeSet,
 		Description: "Agents to use",
 		Required:    true,
 		Elem: &schema.Resource{

--- a/thousandeyes/util.go
+++ b/thousandeyes/util.go
@@ -445,11 +445,18 @@ func FillValue(source interface{}, target interface{}) interface{} {
 	case reflect.Slice:
 		// When the target is a slice, we create a new slice of the same type,
 		// then recurse with the value of each element.
-		vs := reflect.ValueOf(source)
 		tt := reflect.TypeOf(target)
 		tte := reflect.TypeOf(target).Elem() // The type of items in the slice
 		ntte := reflect.New(tte).Elem()
 		newSlice := reflect.New(tt).Elem()
+
+		vs := reflect.ValueOf(source)
+		// If source is a *Set, we dereference it and convert it to a
+		// List so we can iterate over its elements.
+		if vs.Type() == reflect.TypeOf(&schema.Set{}) {
+			vs = reflect.ValueOf(source.(*schema.Set).List())
+		}
+
 		for i := 0; i < vs.Len(); i++ {
 			toAppend := FillValue(vs.Index(i).Interface(), ntte.Interface())
 			appendVal := reflect.ValueOf(toAppend)


### PR DESCRIPTION
The order of the agents does not matter. If we treat them as
schema.TypeList, then we enter a plan-apply loop with the plan
changing the order of the agents.