### PR TITLE
fix(resource_te_bgp): add default for use_public_bgp

### DIFF
--- a/thousandeyes/schemas.go
+++ b/thousandeyes/schemas.go
@@ -1237,6 +1237,7 @@ var schemas = map[string]*schema.Schema{
 		Type:        schema.TypeBool,
 		Description: "Automatically add all available Public BGP Monitors.",
 		Optional:    true,
+		Default:     true,
 	},
 	"use_ntlm": {
 		Type:        schema.TypeBool,

--- a/thousandeyes/util.go
+++ b/thousandeyes/util.go
@@ -186,7 +186,7 @@ func FixReadValues(m interface{}, name string) (interface{}, error) {
 		i := 0
 		for i < len(monitors) {
 			monitor := monitors[i].(map[string]interface{})
-			if monitor["monitor_type"] == "Public" {
+			if *monitor["monitor_type"].(*string) == "Public" {
 				// Remove this item from the slice
 				monitors = append(monitors[:i], monitors[i+1:]...)
 			} else {

--- a/thousandeyes/util_test.go
+++ b/thousandeyes/util_test.go
@@ -187,19 +187,19 @@ func TestFixReadValues(t *testing.T) {
 	// bgp_monitors
 	monitorsInput := []interface{}{
 		map[string]interface{}{
-			"monitor_name": "foo",
-			"monitor_id":   1,
-			"monitor_type": "Public",
+			"monitor_name": thousandeyes.String("foo"),
+			"monitor_id":   thousandeyes.Int(1),
+			"monitor_type": thousandeyes.String("Public"),
 		},
 		map[string]interface{}{
-			"monitor_name": "bar",
-			"monitor_id":   2,
-			"monitor_type": "Private",
+			"monitor_name": thousandeyes.String("bar"),
+			"monitor_id":   thousandeyes.Int(2),
+			"monitor_type": thousandeyes.String("Private"),
 		},
 	}
 	monitorsTarget := []interface{}{
 		map[string]interface{}{
-			"monitor_id": 2,
+			"monitor_id": thousandeyes.Int(2),
 		},
 	}
 	output, err = FixReadValues(monitorsInput, "bgp_monitors")


### PR DESCRIPTION
All public `bgp_monitors` get removed immediately after applying:
 
```
  # thousandeyes_bgp.bgp_test will be updated in-place
  ~ resource "thousandeyes_bgp" "bgp_test" {
        id                       = "2930988"
      - use_public_bgp           = true -> null
        # (12 unchanged attributes hidden)

      - bgp_monitors {
          - monitor_id = 6784 -> null
        }
      - bgp_monitors {
          - monitor_id = 9216 -> null
        }
```

This contribution fixes that problem.