### PR TITLE
refactor!: use int64 for IDs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/hashicorp/terraform-plugin-docs v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.17.0
-	github.com/thousandeyes/thousandeyes-sdk-go/v2 v2.0.0-alpha.5
+	github.com/thousandeyes/thousandeyes-sdk-go/v2 v2.0.0-alpha.6
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -260,8 +260,8 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.2 h1:4jaiDzPyXQvSd7D0EjG45355tLlV3VOECpq10pLC+8s=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
-github.com/thousandeyes/thousandeyes-sdk-go/v2 v2.0.0-alpha.5 h1:ujqnIMeoHNIGIw+M62tq3ExkEvTmgvfYGVwn52AB3QA=
-github.com/thousandeyes/thousandeyes-sdk-go/v2 v2.0.0-alpha.5/go.mod h1:XQouPCy3dIp81Xzkp9bqu6vg7fmE4QQpA6REsLVTDdE=
+github.com/thousandeyes/thousandeyes-sdk-go/v2 v2.0.0-alpha.6 h1:NqwVaKhqWtUwgkUW/d9n4Ku19V2vnndmy0loRPzBFIM=
+github.com/thousandeyes/thousandeyes-sdk-go/v2 v2.0.0-alpha.6/go.mod h1:XQouPCy3dIp81Xzkp9bqu6vg7fmE4QQpA6REsLVTDdE=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/thousandeyes/data_source_thousandeyes_bgp_monitor.go
+++ b/thousandeyes/data_source_thousandeyes_bgp_monitor.go
@@ -51,7 +51,7 @@ func dataSourceThousandeyesBGPMonitorsRead(d *schema.ResourceData, meta interfac
 	var found *thousandeyes.BGPMonitor
 
 	searchName := d.Get("monitor_name").(string)
-	searchMonitorID := d.Get("monitor_id").(int)
+	searchMonitorID := d.Get("monitor_id").(int64)
 
 	BGPMonitors, err := client.GetBPGMonitors()
 	if err != nil {
@@ -73,7 +73,7 @@ func dataSourceThousandeyesBGPMonitorsRead(d *schema.ResourceData, meta interfac
 		return fmt.Errorf("unable to locate any bgp by name: [%s] or ID: [%d]", searchName, searchMonitorID)
 	}
 
-	d.SetId(strconv.Itoa(*found.MonitorID))
+	d.SetId(strconv.FormatInt(*found.MonitorID, 10))
 	err = d.Set("monitor_name", *found.MonitorName)
 	if err != nil {
 		return err

--- a/thousandeyes/provider.go
+++ b/thousandeyes/provider.go
@@ -11,7 +11,7 @@ import (
 
 // Global variable for account group ID, as we must be aware of it in
 // functions that will not have access to it otherwise.
-var account_group_id int
+var account_group_id int64
 
 func New(version string) func() *schema.Provider {
 	return func() *schema.Provider {
@@ -74,7 +74,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	}
 	var err error
 	if opts.AccountID != "" {
-		account_group_id, err = strconv.Atoi(opts.AccountID)
+		account_group_id, err = strconv.ParseInt(opts.AccountID, 10, 64)
 		if err != nil {
 			return nil, err
 		}

--- a/thousandeyes/resource_alert_rule.go
+++ b/thousandeyes/resource_alert_rule.go
@@ -92,7 +92,7 @@ func resourceAlertRuleCreate(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 	id := remote.RuleID
-	d.SetId(strconv.Itoa(*id))
+	d.SetId(strconv.FormatInt(*id, 10))
 	return resourceAlertRuleRead(d, m)
 }
 

--- a/thousandeyes/util.go
+++ b/thousandeyes/util.go
@@ -17,7 +17,7 @@ func expandAgents(v interface{}) thousandeyes.Agents {
 	for _, er := range v.([]interface{}) {
 		rer := er.(map[string]interface{})
 		agent := &thousandeyes.Agent{
-			AgentID: thousandeyes.Int(rer["agent_id"].(int)),
+			AgentID: thousandeyes.Int64(rer["agent_id"].(int64)),
 		}
 		agents = append(agents, *agent)
 	}
@@ -46,7 +46,7 @@ func expandBGPMonitors(v interface{}) thousandeyes.BGPMonitors {
 	for _, er := range v.([]interface{}) {
 		rer := er.(map[string]interface{})
 		bgpMonitor := &thousandeyes.BGPMonitor{
-			MonitorID: thousandeyes.Int(rer["monitor_id"].(int)),
+			MonitorID: thousandeyes.Int64(rer["monitor_id"].(int64)),
 		}
 		bgpMonitors = append(bgpMonitors, *bgpMonitor)
 	}
@@ -264,7 +264,7 @@ func FixReadValues(m interface{}, name string) (interface{}, error) {
 		for i < len(accounts) {
 			account := accounts[i].(map[string]interface{})
 			//  Compare to account group ID stored in global variable.
-			shared_aid := account["aid"].(*int)
+			shared_aid := account["aid"].(*int64)
 			if *shared_aid == account_group_id {
 				// Remove this item from the slice
 				accounts = append(accounts[:i], accounts[i+1:]...)

--- a/thousandeyes/util_test.go
+++ b/thousandeyes/util_test.go
@@ -58,37 +58,37 @@ func TestResourceRead(t *testing.T) {
 func TestResourceReadValue(t *testing.T) {
 	testStruct := thousandeyes.AccountGroupRole{
 		RoleName:                 thousandeyes.String("TestRole"),
-		RoleID:                   thousandeyes.Int(1),
+		RoleID:                   thousandeyes.Int64(1),
 		HasManagementPermissions: thousandeyes.Bool(true),
 		Builtin:                  thousandeyes.Bool(false),
 		Permissions: &[]thousandeyes.Permission{
 			{
 				IsManagementPermission: thousandeyes.Bool(false),
 				Label:                  thousandeyes.String("foo"),
-				PermissionID:           thousandeyes.Int(27),
+				PermissionID:           thousandeyes.Int64(27),
 			},
 			{
 				IsManagementPermission: thousandeyes.Bool(true),
 				Label:                  thousandeyes.String("bar"),
-				PermissionID:           thousandeyes.Int(28),
+				PermissionID:           thousandeyes.Int64(28),
 			},
 		},
 	}
 	resultMap := map[string]interface{}{
 		"role_name":                  thousandeyes.String("TestRole"),
-		"role_id":                    thousandeyes.Int(1),
+		"role_id":                    thousandeyes.Int64(1),
 		"has_management_permissions": thousandeyes.Bool(true),
 		"builtin":                    thousandeyes.Bool(false),
 		"permissions": []map[string]interface{}{
 			{
 				"is_management_permission": thousandeyes.Bool(false),
 				"label":                    thousandeyes.String("foo"),
-				"permission_id":            thousandeyes.Int(27),
+				"permission_id":            thousandeyes.Int64(27),
 			},
 			{
 				"is_management_permission": thousandeyes.Bool(true),
 				"label":                    thousandeyes.String("bar"),
-				"permission_id":            thousandeyes.Int(28),
+				"permission_id":            thousandeyes.Int64(28),
 			},
 		},
 	}
@@ -249,16 +249,16 @@ func TestFixReadValues(t *testing.T) {
 	accountsInput := []interface{}{
 		map[string]interface{}{
 			"name": thousandeyes.String("foo"),
-			"aid":  thousandeyes.Int(1),
+			"aid":  thousandeyes.Int64(1),
 		},
 		map[string]interface{}{
 			"name": thousandeyes.String("bar"),
-			"aid":  thousandeyes.Int(2),
+			"aid":  thousandeyes.Int64(2),
 		},
 	}
 	accountsTarget := []interface{}{
 		map[string]interface{}{
-			"aid": thousandeyes.Int(1),
+			"aid": thousandeyes.Int64(1),
 		},
 	}
 	output, err = FixReadValues(accountsInput, "shared_with_accounts")


### PR DESCRIPTION
Follow latest updates in thousandeyes-sdk-go and use int64 for IDs.