### PR TITLE
fix: check for nil before dereferencing

### DIFF
--- a/thousandeyes/resource_label.go
+++ b/thousandeyes/resource_label.go
@@ -40,11 +40,13 @@ func resourceGroupLabelRead(d *schema.ResourceData, m interface{}) error {
 	// In order to prevent schema conficts for test responses,  we retain
 	// the stored state for tests attached to a group to just a test ID.
 	testIDs := []thousandeyes.GenericTest{}
-	for _, v := range *remote.Tests {
-		test := thousandeyes.GenericTest{TestID: v.TestID}
-		testIDs = append(testIDs, test)
+	if remote.Tests != nil {
+		for _, v := range *remote.Tests {
+			test := thousandeyes.GenericTest{TestID: v.TestID}
+			testIDs = append(testIDs, test)
+		}
 	}
-	*remote.Tests = testIDs
+	remote.Tests = &testIDs
 	err = ResourceRead(d, remote)
 	if err != nil {
 		return err


### PR DESCRIPTION
Fix a crash on creation:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0xa748f2]
```