### PR TITLE
fix: set use_public_bgp to false by default

### DIFF
--- a/thousandeyes/schemas.go
+++ b/thousandeyes/schemas.go
@@ -1181,7 +1181,7 @@ var schemas = map[string]*schema.Schema{
 		Type:        schema.TypeBool,
 		Description: "Enable to automatically add all available Public BGP Monitors to the test.",
 		Optional:    true,
-		Default:     true,
+		Default:     false,
 	},
 	"use_ntlm": {
 		Type:        schema.TypeBool,


### PR DESCRIPTION
We need this to avoid state-change loops such as:
```
~ use_public_bgp          = false -> true
```