### PR TITLE
fix: validate that domain has a record type suffix

### DIFF
--- a/docs/resources/bgp.md
+++ b/docs/resources/bgp.md
@@ -15,7 +15,8 @@ resource "thousandeyes_bgp" "example_bgp_test" {
   test_name      = "Example BGP test set from Terraform provider"
   alerts_enabled = false
 
-  prefix = "163.10.0.0/16"
+  use_public_bgp = true
+  prefix         = "163.10.0.0/16"
 }
 ```
 

--- a/docs/resources/voice.md
+++ b/docs/resources/voice.md
@@ -12,9 +12,12 @@ description: |-
 
 ```terraform
 resource "thousandeyes_voice" "example_voice_test" {
-  test_name      = "Example RTP stream test set from Terraform provider"
-  interval       = 120
-  alerts_enabled = false
+  test_name        = "Example RTP stream test set from Terraform provider"
+  interval         = 120
+  alerts_enabled   = false
+
+  bgp_measurements = true
+  use_public_bgp   = true
 
   target_agent_id = 4 # Tokyo
 

--- a/examples/resources/thousandeyes_bgp/resource.tf
+++ b/examples/resources/thousandeyes_bgp/resource.tf
@@ -2,5 +2,6 @@ resource "thousandeyes_bgp" "example_bgp_test" {
   test_name      = "Example BGP test set from Terraform provider"
   alerts_enabled = false
 
-  prefix = "163.10.0.0/16"
+  use_public_bgp = true
+  prefix         = "163.10.0.0/16"
 }

--- a/examples/resources/thousandeyes_voice/resource.tf
+++ b/examples/resources/thousandeyes_voice/resource.tf
@@ -1,7 +1,10 @@
 resource "thousandeyes_voice" "example_voice_test" {
-  test_name      = "Example RTP stream test set from Terraform provider"
-  interval       = 120
-  alerts_enabled = false
+  test_name        = "Example RTP stream test set from Terraform provider"
+  interval         = 120
+  alerts_enabled   = false
+
+  bgp_measurements = true
+  use_public_bgp   = true
 
   target_agent_id = 4 # Tokyo
 

--- a/thousandeyes/schemas.go
+++ b/thousandeyes/schemas.go
@@ -1,6 +1,8 @@
 package thousandeyes
 
 import (
+	"regexp"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -520,6 +522,10 @@ var schemas = map[string]*schema.Schema{
 		Description: "See notes	target record for test, suffixed by record type (ie, www.thousandeyes.com CNAME). If no record type is specified, the test will default to an ANY record.",
 		Optional: false,
 		Required: true,
+		ValidateFunc: validation.StringMatch(
+			regexp.MustCompile(`^.* (A|ANY|NS|CNAME|MX|SOA|AAAA|PTR|TXT|NULL|DS|RRSIG|DNSKEY|NSEC)$`),
+			"must suffix with record type; check ThousandEyes Developer Reference for more information",
+		),
 	},
 	"download_limit": {
 		Type:        schema.TypeInt,


### PR DESCRIPTION
Force domain in dns_server to always have a record type. According to
TE documentation:

> If no record type is specified, the test will default to an ANY record.

This does not play well with the Terraform state:
```
~ resource "thousandeyes_dns_server" "example_dns_server_test" {
      ~ domain                 = "www.thousandeyes.com ANY" -> "www.thousandeyes.com"
```

Additionally, this pull request updates some examples with the correct usage of `use_public_bgp`.