### PR TITLE
feat: sets HTTP client's User Agent to "ThousandEyes Terraform Provider"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/hashicorp/terraform-plugin-docs v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.17.0
-	github.com/thousandeyes/thousandeyes-sdk-go/v2 v2.0.0-beta
+	github.com/thousandeyes/thousandeyes-sdk-go/v2 v2.1.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -260,8 +260,8 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.2 h1:4jaiDzPyXQvSd7D0EjG45355tLlV3VOECpq10pLC+8s=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
-github.com/thousandeyes/thousandeyes-sdk-go/v2 v2.0.0-beta h1:GNn9Ab2aNU2BDxJWJEA29eAfRcQ8yMLB9vhcT1KbDZI=
-github.com/thousandeyes/thousandeyes-sdk-go/v2 v2.0.0-beta/go.mod h1:XQouPCy3dIp81Xzkp9bqu6vg7fmE4QQpA6REsLVTDdE=
+github.com/thousandeyes/thousandeyes-sdk-go/v2 v2.1.0 h1:0tR78mOjX3bccfcnerb6x0adp0fX5sJJK0QOXSmIgLA=
+github.com/thousandeyes/thousandeyes-sdk-go/v2 v2.1.0/go.mod h1:XQouPCy3dIp81Xzkp9bqu6vg7fmE4QQpA6REsLVTDdE=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/thousandeyes/provider.go
+++ b/thousandeyes/provider.go
@@ -74,6 +74,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		AuthToken: d.Get("token").(string),
 		AccountID: d.Get("account_group_id").(string),
 		Timeout:   time.Second * time.Duration(d.Get("timeout").(int)),
+		UserAgent: "ThousandEyes Terraform Provider",
 	}
 	var err error
 	if opts.AccountID != "" {


### PR DESCRIPTION
This is hardcoded in the provider so we know what to expect and what to query to determine which API requests are coming from the terraform provider