### PR TITLE
fix: fixes agent_to_server ICMP tests which should not require a port

### DIFF
--- a/thousandeyes/resource_agent_to_agent.go
+++ b/thousandeyes/resource_agent_to_agent.go
@@ -5,12 +5,23 @@ import (
 	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/thousandeyes/thousandeyes-sdk-go/v2"
 )
 
 func resourceAgentToAgent() *schema.Resource {
+	agentToAgentSchemasOverride := map[string]*schema.Schema{
+		"port": {
+			Type:         schema.TypeInt,
+			Description:  "The target port.",
+			ValidateFunc: validation.IntBetween(1, 65535),
+			Default:      49153,
+			Optional:     true,
+		},
+	}
+
 	resource := schema.Resource{
-		Schema: ResourceSchemaBuild(thousandeyes.AgentAgent{}, schemas),
+		Schema: ResourceSchemaBuild(thousandeyes.AgentAgent{}, schemas, agentToAgentSchemasOverride),
 		Create: resourceAgentAgentCreate,
 		Read:   resourceAgentAgentRead,
 		Update: resourceAgentAgentUpdate,

--- a/thousandeyes/resource_agent_to_server.go
+++ b/thousandeyes/resource_agent_to_server.go
@@ -5,12 +5,27 @@ import (
 	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/thousandeyes/thousandeyes-sdk-go/v2"
 )
 
 func resourceAgentToServer() *schema.Resource {
+	agentToServerSchemasOverride := map[string]*schema.Schema{
+		"port": {
+			Type:         schema.TypeInt,
+			Description:  "The target port.",
+			ValidateFunc: validation.IntBetween(1, 65535),
+			Optional:     true,
+			DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
+				// allows port to be optional even for TCP tests
+				// it uses ThousandEyes' default which is 80
+				return newValue == "0"
+			},
+		},
+	}
+
 	resource := schema.Resource{
-		Schema: ResourceSchemaBuild(thousandeyes.AgentServer{}, schemas),
+		Schema: ResourceSchemaBuild(thousandeyes.AgentServer{}, schemas, agentToServerSchemasOverride),
 		Create: resourceAgentServerCreate,
 		Read:   resourceAgentServerRead,
 		Update: resourceAgentServerUpdate,

--- a/thousandeyes/resource_alert_rule.go
+++ b/thousandeyes/resource_alert_rule.go
@@ -10,7 +10,7 @@ import (
 
 func resourceAlertRule() *schema.Resource {
 	resource := schema.Resource{
-		Schema: ResourceSchemaBuild(thousandeyes.AlertRule{}, schemas),
+		Schema: ResourceSchemaBuild(thousandeyes.AlertRule{}, schemas, nil),
 		Create: resourceAlertRuleCreate,
 		Read:   resourceAlertRuleRead,
 		Update: resourceAlertRuleUpdate,

--- a/thousandeyes/resource_bgp.go
+++ b/thousandeyes/resource_bgp.go
@@ -10,7 +10,7 @@ import (
 
 func resourceBGP() *schema.Resource {
 	resource := schema.Resource{
-		Schema: ResourceSchemaBuild(thousandeyes.BGP{}, schemas),
+		Schema: ResourceSchemaBuild(thousandeyes.BGP{}, schemas, nil),
 		Create: resourceBGPCreate,
 		Read:   resourceBGPRead,
 		Update: resourceBGPUpdate,

--- a/thousandeyes/resource_dns_server.go
+++ b/thousandeyes/resource_dns_server.go
@@ -10,7 +10,7 @@ import (
 
 func resourceDNSServer() *schema.Resource {
 	resource := schema.Resource{
-		Schema: ResourceSchemaBuild(thousandeyes.DNSServer{}, schemas),
+		Schema: ResourceSchemaBuild(thousandeyes.DNSServer{}, schemas, nil),
 		Create: resourceDNSServerCreate,
 		Read:   resourceDNSServerRead,
 		Update: resourceDNSServerUpdate,

--- a/thousandeyes/resource_dns_trace.go
+++ b/thousandeyes/resource_dns_trace.go
@@ -10,7 +10,7 @@ import (
 
 func resourceDNSTrace() *schema.Resource {
 	resource := schema.Resource{
-		Schema: ResourceSchemaBuild(thousandeyes.DNSTrace{}, schemas),
+		Schema: ResourceSchemaBuild(thousandeyes.DNSTrace{}, schemas, nil),
 		Create: resourceDNSTraceCreate,
 		Read:   resourceDNSTraceRead,
 		Update: resourceDNSTraceUpdate,

--- a/thousandeyes/resource_dnssec.go
+++ b/thousandeyes/resource_dnssec.go
@@ -12,7 +12,7 @@ import (
 
 func resourceDNSSec() *schema.Resource {
 	resource := schema.Resource{
-		Schema: ResourceSchemaBuild(thousandeyes.DNSSec{}, schemas),
+		Schema: ResourceSchemaBuild(thousandeyes.DNSSec{}, schemas, nil),
 		Create: resourceDNSSecCreate,
 		Read:   resourceDNSSecRead,
 		Update: resourceDNSSecUpdate,

--- a/thousandeyes/resource_ftp_server.go
+++ b/thousandeyes/resource_ftp_server.go
@@ -10,7 +10,7 @@ import (
 
 func resourceFTPServer() *schema.Resource {
 	resource := schema.Resource{
-		Schema: ResourceSchemaBuild(thousandeyes.FTPServer{}, schemas),
+		Schema: ResourceSchemaBuild(thousandeyes.FTPServer{}, schemas, nil),
 		Create: resourceFTPServerCreate,
 		Read:   resourceFTPServerRead,
 		Update: resourceFTPServerUpdate,

--- a/thousandeyes/resource_http_server.go
+++ b/thousandeyes/resource_http_server.go
@@ -10,7 +10,7 @@ import (
 
 func resourceHTTPServer() *schema.Resource {
 	resource := schema.Resource{
-		Schema: ResourceSchemaBuild(thousandeyes.HTTPServer{}, schemas),
+		Schema: ResourceSchemaBuild(thousandeyes.HTTPServer{}, schemas, nil),
 		Create: resourceHTTPServerCreate,
 		Read:   resourceHTTPServerRead,
 		Update: resourceHTTPServerUpdate,

--- a/thousandeyes/resource_label.go
+++ b/thousandeyes/resource_label.go
@@ -10,7 +10,7 @@ import (
 
 func resourceGroupLabel() *schema.Resource {
 	resource := schema.Resource{
-		Schema: ResourceSchemaBuild(thousandeyes.GroupLabel{}, schemas),
+		Schema: ResourceSchemaBuild(thousandeyes.GroupLabel{}, schemas, nil),
 		Create: resourceGroupLabelCreate,
 		Read:   resourceGroupLabelRead,
 		Update: resourceGroupLabelUpdate,
@@ -23,7 +23,7 @@ func resourceGroupLabel() *schema.Resource {
 	resource.Schema["type"] = schemas["type-label"]
 	resource.Schema["agents"] = schemas["agents-label"]
 	resource.Schema["tests"].Elem = &schema.Resource{
-		Schema: ResourceSchemaBuild(thousandeyes.GenericTest{}, schemas),
+		Schema: ResourceSchemaBuild(thousandeyes.GenericTest{}, schemas, nil),
 	}
 	return &resource
 }

--- a/thousandeyes/resource_page_load.go
+++ b/thousandeyes/resource_page_load.go
@@ -10,7 +10,7 @@ import (
 
 func resourcePageLoad() *schema.Resource {
 	resource := schema.Resource{
-		Schema: ResourceSchemaBuild(thousandeyes.PageLoad{}, schemas),
+		Schema: ResourceSchemaBuild(thousandeyes.PageLoad{}, schemas, nil),
 		Create: resourcePageLoadCreate,
 		Read:   resourcePageLoadRead,
 		Update: resourcePageLoadUpdate,

--- a/thousandeyes/resource_sip_server.go
+++ b/thousandeyes/resource_sip_server.go
@@ -10,7 +10,7 @@ import (
 
 func resourceSIPServer() *schema.Resource {
 	resource := schema.Resource{
-		Schema: ResourceSchemaBuild(thousandeyes.SIPServer{}, schemas),
+		Schema: ResourceSchemaBuild(thousandeyes.SIPServer{}, schemas, nil),
 		Create: resourceSIPServerCreate,
 		Read:   resourceSIPServerRead,
 		Update: resourceSIPServerUpdate,

--- a/thousandeyes/resource_voice.go
+++ b/thousandeyes/resource_voice.go
@@ -10,7 +10,7 @@ import (
 
 func resourceRTPStream() *schema.Resource {
 	resource := schema.Resource{
-		Schema: ResourceSchemaBuild(thousandeyes.RTPStream{}, schemas),
+		Schema: ResourceSchemaBuild(thousandeyes.RTPStream{}, schemas, nil),
 		Create: resourceRTPStreamCreate,
 		Read:   resourceRTPStreamRead,
 		Update: resourceRTPStreamUpdate,

--- a/thousandeyes/resource_web_transactions.go
+++ b/thousandeyes/resource_web_transactions.go
@@ -10,7 +10,7 @@ import (
 
 func resourceWebTransaction() *schema.Resource {
 	resource := schema.Resource{
-		Schema: ResourceSchemaBuild(thousandeyes.WebTransaction{}, schemas),
+		Schema: ResourceSchemaBuild(thousandeyes.WebTransaction{}, schemas, nil),
 		Create: resourceWebTransactionCreate,
 		Read:   resourceWebTransactionRead,
 		Update: resourceWebTransactionUpdate,

--- a/thousandeyes/schemas.go
+++ b/thousandeyes/schemas.go
@@ -518,10 +518,10 @@ var schemas = map[string]*schema.Schema{
 		ValidateFunc: validation.StringInSlice([]string{"UDP", "TCP"}, false),
 	},
 	"domain": {
-		Type: schema.TypeString,
+		Type:        schema.TypeString,
 		Description: "See notes	target record for test, suffixed by record type (ie, www.thousandeyes.com CNAME). If no record type is specified, the test will default to an ANY record.",
-		Optional: false,
-		Required: true,
+		Optional:    false,
+		Required:    true,
 		ValidateFunc: validation.StringMatch(
 			regexp.MustCompile(`^.* (A|ANY|NS|CNAME|MX|SOA|AAAA|PTR|TXT|NULL|DS|RRSIG|DNSKEY|NSEC)$`),
 			"must suffix with record type; check ThousandEyes Developer Reference for more information",
@@ -870,14 +870,6 @@ var schemas = map[string]*schema.Schema{
 		Required:     false,
 		Default:      "classic",
 		ValidateFunc: validation.StringInSlice([]string{"classic", "inSession"}, false),
-	},
-	"port": {
-		Type:         schema.TypeInt,
-		Description:  "The target port.",
-		ValidateFunc: validation.IntBetween(1, 65535),
-		Default:      49153,
-		Optional:     true,
-		Required:     false,
 	},
 	"post_body": {
 		Type:        schema.TypeString,

--- a/thousandeyes/util.go
+++ b/thousandeyes/util.go
@@ -431,7 +431,7 @@ func ResourceUpdate(d *schema.ResourceData, structPtr interface{}) interface{} {
 
 // ResourceSchemaBuild creates a map of schemas based on the fields
 // of the provided struct.
-func ResourceSchemaBuild(referenceStruct interface{}, schemas map[string]*schema.Schema) map[string]*schema.Schema {
+func ResourceSchemaBuild(referenceStruct interface{}, schemas map[string]*schema.Schema, schemasOverride map[string]*schema.Schema) map[string]*schema.Schema {
 	newSchema := map[string]*schema.Schema{}
 	v := reflect.ValueOf(referenceStruct)
 	t := reflect.TypeOf(referenceStruct)
@@ -439,8 +439,18 @@ func ResourceSchemaBuild(referenceStruct interface{}, schemas map[string]*schema
 	for i := 0; i < v.NumField(); i++ {
 		tag := GetJSONKey(t.Field(i))
 		tfName := CamelCaseToUnderscore(tag)
-		if val, ok := schemas[tfName]; ok {
-			newSchema[tfName] = val
+
+		// use the override if there is one
+		if schemasOverride != nil && len(schemasOverride) > 0 {
+			if val, ok := schemasOverride[tfName]; ok {
+				newSchema[tfName] = val
+			} else if val, ok := schemas[tfName]; ok {
+				newSchema[tfName] = val
+			}
+		} else {
+			if val, ok := schemas[tfName]; ok {
+				newSchema[tfName] = val
+			}
 		}
 	}
 	return newSchema

--- a/thousandeyes/util_test.go
+++ b/thousandeyes/util_test.go
@@ -334,15 +334,22 @@ func TestResourceUpdate(t *testing.T) {
 func TestResourceSchemaBuild(t *testing.T) {
 	type refStruct struct {
 		FieldName string `json:"fieldName"`
+		Port      int    `json:"port"`
 	}
 
 	refSchema := map[string]*schema.Schema{
 		"field_name": {
 			Type: schema.TypeString,
 		},
+		"port": {
+			Type:     schema.TypeInt,
+			Default:  41953,
+			Optional: true,
+		},
 	}
 
-	schm := ResourceSchemaBuild(refStruct{}, refSchema)
+	// test with no schema override
+	schm := ResourceSchemaBuild(refStruct{}, refSchema, nil)
 
 	for k, v := range refSchema {
 		if _, ok := schm[k]; !ok {
@@ -353,6 +360,34 @@ func TestResourceSchemaBuild(t *testing.T) {
 		}
 	}
 
+	// test with a schema override
+	schemaOverride := map[string]*schema.Schema{
+		"port": {
+			Type:     schema.TypeInt,
+			Optional: true,
+		},
+	}
+
+	expectedSchemaWithOverride := map[string]*schema.Schema{
+		"field_name": {
+			Type: schema.TypeString,
+		},
+		"port": {
+			Type:     schema.TypeInt,
+			Optional: true,
+		},
+	}
+
+	ovrSchm := ResourceSchemaBuild(refStruct{}, refSchema, schemaOverride)
+
+	for k, v := range expectedSchemaWithOverride {
+		if _, ok := ovrSchm[k]; !ok {
+			t.Errorf("Key %s missing from generated schema", k)
+		}
+		if reflect.DeepEqual(*v, *ovrSchm[k]) != true {
+			t.Errorf("Schemas not equal: Expected schema is %+v\nNew Schema is %+v", expectedSchemaWithOverride, ovrSchm)
+		}
+	}
 }
 
 func TestFillValue(t *testing.T) {


### PR DESCRIPTION
Terraform was always passing a port on `agent_to_agent` and `agent_to_server` tests. This is fine for `agent_to_agent` as that test type does indeed require a port to be passed, but not for `agent_to_server` since `ICMP` based tests mustn't contain a port and `TCP` tests do not require the port to be passed (it'll default to 80 on ThousandEyes).

There are many approaches possible to fix this, but my constraints were:
  * Keep using the common `schemas` variable
  * Not separate `agent_to_server` resource into two resources: one for ICMP and one for TCP (which would allow us to create a specific port schema for each)

These constraints meant that the port had to be optional and not have default value for the `agent_to_server` resource. This meant that the schema definition for the port had to be different for `agent_to_agent` and `agent_to_server`, so I created this schema override logic. 

Additionally, since port is now optional and has no default for `agent_to_server`, this means that `agent_to_server` TCP based resources/tests are now created using ThousandEyes' default port, which is 80. This also means that terraform will try to change the port back to 0 on every plan if using the ThousandEyes' default. To address this I used the `DiffSuppressFunc`, which checks if the new value of the port is `"0"`.
  * The side effect of this is that you can create a new TCP based `agent_to_server` test with some port and then later remove the port parameter from the resource, and terraform will suppress the change. IMO this isn't a big deal. The previous behaviour would be to change the port to the terraform default which was 41953. I think I would rather have it not change the value then set it to 41953.

Let me hear your thoughts! 

```
go vet ./... && echo && go test ./...

?   	github.com/thousandeyes/terraform-provider-thousandeyes	[no test files]
ok  	github.com/thousandeyes/terraform-provider-thousandeyes/thousandeyes	0.427s
```