### PR TITLE
update: thousandeyes sdk from v2.1.0 to v2.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/hashicorp/terraform-plugin-docs v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.17.0
-	github.com/thousandeyes/thousandeyes-sdk-go/v2 v2.1.0
+	github.com/thousandeyes/thousandeyes-sdk-go/v2 v2.2.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -260,8 +260,8 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.2 h1:4jaiDzPyXQvSd7D0EjG45355tLlV3VOECpq10pLC+8s=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
-github.com/thousandeyes/thousandeyes-sdk-go/v2 v2.1.0 h1:0tR78mOjX3bccfcnerb6x0adp0fX5sJJK0QOXSmIgLA=
-github.com/thousandeyes/thousandeyes-sdk-go/v2 v2.1.0/go.mod h1:XQouPCy3dIp81Xzkp9bqu6vg7fmE4QQpA6REsLVTDdE=
+github.com/thousandeyes/thousandeyes-sdk-go/v2 v2.2.0 h1:Fb7v34lvhBndbo6KErtEtSQ69g1pOP2eliq8LeGs5gU=
+github.com/thousandeyes/thousandeyes-sdk-go/v2 v2.2.0/go.mod h1:XQouPCy3dIp81Xzkp9bqu6vg7fmE4QQpA6REsLVTDdE=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/thousandeyes/schemas.go
+++ b/thousandeyes/schemas.go
@@ -811,6 +811,55 @@ var schemas = map[string]*schema.Schema{
 						},
 					},
 				},
+				"thirdParty": {
+					Type:        schema.TypeSet,
+					Description: "Third party notification.",
+					Optional:    true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"integrationId": {
+								Type:        schema.TypeString,
+								Description: "The integration ID, as a string.",
+								Optional:    true,
+							},
+							"integrationName": {
+								Type:        schema.TypeString,
+								Description: "The integration name, as a string.",
+								Optional:    true,
+							},
+							"integrationType": {
+								Type:        schema.TypeString,
+								Description: "The integration type, as a string.",
+								Optional:    true,
+							},
+							"target": {
+								Type:        schema.TypeString,
+								Description: "The target, as a string.",
+								Optional:    true,
+							},
+							"authMethod": {
+								Type:        schema.TypeString,
+								Description: "The authentication method, as a string.",
+								Optional:    true,
+							},
+							"authUser": {
+								Type:        schema.TypeString,
+								Description: "The authentication user, as a string.",
+								Optional:    true,
+							},
+							"authToken": {
+								Type:        schema.TypeString,
+								Description: "The authentication token, as a string.",
+								Optional:    true,
+							},
+							"channel": {
+								Type:        schema.TypeString,
+								Description: "The channel to notify, as a string.",
+								Optional:    true,
+							},
+						},
+					},
+				},
 			},
 		},
 	},


### PR DESCRIPTION
Hey there `terraform-provider-thousandeyes` maintainers 👋🏼 

A new version of `thousandeyes-sdk-go` has been released ([v2.2.0](https://github.com/thousandeyes/thousandeyes-sdk-go/releases/tag/v2.2.0)), this PR updates the dependency on the SDK to the latest version so the T.E terraform provider can make use of new features in the SDK.

The above mentioned release only contains https://github.com/thousandeyes/thousandeyes-sdk-go/pull/110 as far as I know.

go test looks good:

```
~/src/terraform-provider-thousandeyes (main) $ go test ./...
?       github.com/thousandeyes/terraform-provider-thousandeyes [no test files]
ok      github.com/thousandeyes/terraform-provider-thousandeyes/thousandeyes    0.050s
```

Please let me know if there is anything else needed. 🙇🏼 