### PR TITLE
fix: fixes group ordering, no longer required

### DIFF
--- a/docs/resources/agent_to_agent.md
+++ b/docs/resources/agent_to_agent.md
@@ -47,7 +47,7 @@ resource "thousandeyes_agent_to_agent" "example_agent_to_agent_test" {
 - `description` (String) A description of the alert rule. Defaults to an empty string.
 - `dscp_id` (Number) The DSCP ID.
 - `enabled` (Boolean) Enables or disables the test.
-- `groups` (Block List) The array of label objects. (see [below for nested schema](#nestedblock--groups))
+- `groups` (Block Set) The array of label objects. (see [below for nested schema](#nestedblock--groups))
 - `mss` (Number) The maximum segment size, in bytes. Value can be from 30 to 1400.
 - `mtu_measurements` (Boolean) Measure MTU sizes on the network from agents to the target.
 - `network_measurements` (Boolean) Set to 'true' to enable network measurements.
@@ -87,7 +87,7 @@ Optional:
 - `created_date` (String) The date the agent was created. Expressed in UTC (yyyy-MM-dd hh:mm:ss).
 - `enabled` (Boolean) Shows whether the agent is enabled or disabled.
 - `error_details` (Block List) If one or more errors present in the agent, the error details are shown for each as an array. (see [below for nested schema](#nestedblock--agents--error_details))
-- `groups` (Block List) An array of label objects. (see [below for nested schema](#nestedblock--agents--groups))
+- `groups` (Block Set) An array of label objects. (see [below for nested schema](#nestedblock--agents--groups))
 - `hostname` (String) Fully qualified domain name of the agent.
 - `ip_addresses` (List of String) An array of the ipAddress entries.
 - `ipv6_policy` (String) [FORCE_IPV4, PREFER_IPV6 or FORCE_IPV6] The IP version policy.
@@ -135,7 +135,7 @@ Optional:
 
 Optional:
 
-- `builtin` (Number) Shows whether you are using built-in (1) labels or user-created (2) labels. Built-in labels are read-only.
+- `builtin` (Boolean) Shows whether you are using built-in (1) labels or user-created (2) labels. Built-in labels are read-only.
 - `group_id` (Number) The unique ID of the label. This number is negative for built-in labels. Query the /groups/{id} endpoint to see a list of agents/tests with this label.
 - `name` (String) The name of the label.
 - `type` (String) [tests, agents, endpoint_tests or endpoint_agents] The type of label.

--- a/docs/resources/agent_to_server.md
+++ b/docs/resources/agent_to_server.md
@@ -45,7 +45,7 @@ resource "thousandeyes_agent_to_server" "example_agent_to_server_test" {
 - `bgp_monitors` (Block List) The array of BGP monitor object IDs. The monitorIDs can be sourced from the /bgp-monitors endpoint. (see [below for nested schema](#nestedblock--bgp_monitors))
 - `description` (String) A description of the alert rule. Defaults to an empty string.
 - `enabled` (Boolean) Enables or disables the test.
-- `groups` (Block List) The array of label objects. (see [below for nested schema](#nestedblock--groups))
+- `groups` (Block Set) The array of label objects. (see [below for nested schema](#nestedblock--groups))
 - `mtu_measurements` (Boolean) Measure MTU sizes on the network from agents to the target.
 - `network_measurements` (Boolean) Set to 'true' to enable network measurements.
 - `num_path_traces` (Number) The number of path traces.
@@ -82,7 +82,7 @@ Optional:
 - `created_date` (String) The date the agent was created. Expressed in UTC (yyyy-MM-dd hh:mm:ss).
 - `enabled` (Boolean) Shows whether the agent is enabled or disabled.
 - `error_details` (Block List) If one or more errors present in the agent, the error details are shown for each as an array. (see [below for nested schema](#nestedblock--agents--error_details))
-- `groups` (Block List) An array of label objects. (see [below for nested schema](#nestedblock--agents--groups))
+- `groups` (Block Set) An array of label objects. (see [below for nested schema](#nestedblock--agents--groups))
 - `hostname` (String) Fully qualified domain name of the agent.
 - `ip_addresses` (List of String) An array of the ipAddress entries.
 - `ipv6_policy` (String) [FORCE_IPV4, PREFER_IPV6 or FORCE_IPV6] The IP version policy.
@@ -130,7 +130,7 @@ Optional:
 
 Optional:
 
-- `builtin` (Number) Shows whether you are using built-in (1) labels or user-created (2) labels. Built-in labels are read-only.
+- `builtin` (Boolean) Shows whether you are using built-in (1) labels or user-created (2) labels. Built-in labels are read-only.
 - `group_id` (Number) The unique ID of the label. This number is negative for built-in labels. Query the /groups/{id} endpoint to see a list of agents/tests with this label.
 - `name` (String) The name of the label.
 - `type` (String) [tests, agents, endpoint_tests or endpoint_agents] The type of label.

--- a/docs/resources/bgp.md
+++ b/docs/resources/bgp.md
@@ -35,7 +35,7 @@ resource "thousandeyes_bgp" "example_bgp_test" {
 - `bgp_monitors` (Block List) The array of BGP monitor object IDs. The monitorIDs can be sourced from the /bgp-monitors endpoint. (see [below for nested schema](#nestedblock--bgp_monitors))
 - `description` (String) A description of the alert rule. Defaults to an empty string.
 - `enabled` (Boolean) Enables or disables the test.
-- `groups` (Block List) The array of label objects. (see [below for nested schema](#nestedblock--groups))
+- `groups` (Block Set) The array of label objects. (see [below for nested schema](#nestedblock--groups))
 - `include_covered_prefixes` (Boolean) Include queries for subprefixes detected under this prefix.
 - `shared_with_accounts` (Block List) [“serverName”: “fqdn of server”] The array of DNS Server objects. (see [below for nested schema](#nestedblock--shared_with_accounts))
 - `use_public_bgp` (Boolean) Enable to automatically add all available Public BGP Monitors to the test.

--- a/docs/resources/dns_server.md
+++ b/docs/resources/dns_server.md
@@ -49,7 +49,7 @@ resource "thousandeyes_dns_server" "example_dns_server_test" {
 - `description` (String) A description of the alert rule. Defaults to an empty string.
 - `dns_transport_protocol` (String) [UDP or TCP] The DNS transport protocol used for DNS requests. Defaults to UDP.
 - `enabled` (Boolean) Enables or disables the test.
-- `groups` (Block List) The array of label objects. (see [below for nested schema](#nestedblock--groups))
+- `groups` (Block Set) The array of label objects. (see [below for nested schema](#nestedblock--groups))
 - `mtu_measurements` (Boolean) Measure MTU sizes on the network from agents to the target.
 - `network_measurements` (Boolean) Set to 'true' to enable network measurements.
 - `num_path_traces` (Number) The number of path traces.
@@ -86,7 +86,7 @@ Optional:
 - `created_date` (String) The date the agent was created. Expressed in UTC (yyyy-MM-dd hh:mm:ss).
 - `enabled` (Boolean) Shows whether the agent is enabled or disabled.
 - `error_details` (Block List) If one or more errors present in the agent, the error details are shown for each as an array. (see [below for nested schema](#nestedblock--agents--error_details))
-- `groups` (Block List) An array of label objects. (see [below for nested schema](#nestedblock--agents--groups))
+- `groups` (Block Set) An array of label objects. (see [below for nested schema](#nestedblock--agents--groups))
 - `hostname` (String) Fully qualified domain name of the agent.
 - `ip_addresses` (List of String) An array of the ipAddress entries.
 - `ipv6_policy` (String) [FORCE_IPV4, PREFER_IPV6 or FORCE_IPV6] The IP version policy.
@@ -134,7 +134,7 @@ Optional:
 
 Optional:
 
-- `builtin` (Number) Shows whether you are using built-in (1) labels or user-created (2) labels. Built-in labels are read-only.
+- `builtin` (Boolean) Shows whether you are using built-in (1) labels or user-created (2) labels. Built-in labels are read-only.
 - `group_id` (Number) The unique ID of the label. This number is negative for built-in labels. Query the /groups/{id} endpoint to see a list of agents/tests with this label.
 - `name` (String) The name of the label.
 - `type` (String) [tests, agents, endpoint_tests or endpoint_agents] The type of label.

--- a/docs/resources/dns_trace.md
+++ b/docs/resources/dns_trace.md
@@ -27,7 +27,7 @@ This resource provides users with the ability to create a DNS trace test. This t
 - `description` (String) A description of the alert rule. Defaults to an empty string.
 - `dns_transport_protocol` (String) [UDP or TCP] The DNS transport protocol used for DNS requests. Defaults to UDP.
 - `enabled` (Boolean) Enables or disables the test.
-- `groups` (Block List) The array of label objects. (see [below for nested schema](#nestedblock--groups))
+- `groups` (Block Set) The array of label objects. (see [below for nested schema](#nestedblock--groups))
 - `shared_with_accounts` (Block List) [“serverName”: “fqdn of server”] The array of DNS Server objects. (see [below for nested schema](#nestedblock--shared_with_accounts))
 
 ### Read-Only
@@ -56,7 +56,7 @@ Optional:
 - `created_date` (String) The date the agent was created. Expressed in UTC (yyyy-MM-dd hh:mm:ss).
 - `enabled` (Boolean) Shows whether the agent is enabled or disabled.
 - `error_details` (Block List) If one or more errors present in the agent, the error details are shown for each as an array. (see [below for nested schema](#nestedblock--agents--error_details))
-- `groups` (Block List) An array of label objects. (see [below for nested schema](#nestedblock--agents--groups))
+- `groups` (Block Set) An array of label objects. (see [below for nested schema](#nestedblock--agents--groups))
 - `hostname` (String) Fully qualified domain name of the agent.
 - `ip_addresses` (List of String) An array of the ipAddress entries.
 - `ipv6_policy` (String) [FORCE_IPV4, PREFER_IPV6 or FORCE_IPV6] The IP version policy.
@@ -104,7 +104,7 @@ Optional:
 
 Optional:
 
-- `builtin` (Number) Shows whether you are using built-in (1) labels or user-created (2) labels. Built-in labels are read-only.
+- `builtin` (Boolean) Shows whether you are using built-in (1) labels or user-created (2) labels. Built-in labels are read-only.
 - `group_id` (Number) The unique ID of the label. This number is negative for built-in labels. Query the /groups/{id} endpoint to see a list of agents/tests with this label.
 - `name` (String) The name of the label.
 - `type` (String) [tests, agents, endpoint_tests or endpoint_agents] The type of label.

--- a/docs/resources/dnssec.md
+++ b/docs/resources/dnssec.md
@@ -26,7 +26,7 @@ This resource allows you to create a DNSSEC test. This test type verifies the di
 - `alerts_enabled` (Boolean) Set to 'true' to enable alerts, or 'false' to disable alerts. The default value is 'true'.
 - `description` (String) A description of the alert rule. Defaults to an empty string.
 - `enabled` (Boolean) Enables or disables the test.
-- `groups` (Block List) The array of label objects. (see [below for nested schema](#nestedblock--groups))
+- `groups` (Block Set) The array of label objects. (see [below for nested schema](#nestedblock--groups))
 - `shared_with_accounts` (Block List) [“serverName”: “fqdn of server”] The array of DNS Server objects. (see [below for nested schema](#nestedblock--shared_with_accounts))
 
 ### Read-Only
@@ -55,7 +55,7 @@ Optional:
 - `created_date` (String) The date the agent was created. Expressed in UTC (yyyy-MM-dd hh:mm:ss).
 - `enabled` (Boolean) Shows whether the agent is enabled or disabled.
 - `error_details` (Block List) If one or more errors present in the agent, the error details are shown for each as an array. (see [below for nested schema](#nestedblock--agents--error_details))
-- `groups` (Block List) An array of label objects. (see [below for nested schema](#nestedblock--agents--groups))
+- `groups` (Block Set) An array of label objects. (see [below for nested schema](#nestedblock--agents--groups))
 - `hostname` (String) Fully qualified domain name of the agent.
 - `ip_addresses` (List of String) An array of the ipAddress entries.
 - `ipv6_policy` (String) [FORCE_IPV4, PREFER_IPV6 or FORCE_IPV6] The IP version policy.
@@ -103,7 +103,7 @@ Optional:
 
 Optional:
 
-- `builtin` (Number) Shows whether you are using built-in (1) labels or user-created (2) labels. Built-in labels are read-only.
+- `builtin` (Boolean) Shows whether you are using built-in (1) labels or user-created (2) labels. Built-in labels are read-only.
 - `group_id` (Number) The unique ID of the label. This number is negative for built-in labels. Query the /groups/{id} endpoint to see a list of agents/tests with this label.
 - `name` (String) The name of the label.
 - `type` (String) [tests, agents, endpoint_tests or endpoint_agents] The type of label.

--- a/docs/resources/ftp_server.md
+++ b/docs/resources/ftp_server.md
@@ -33,7 +33,7 @@ This resource allows you to create an FTP server test. This test type verifies t
 - `enabled` (Boolean) Enables or disables the test.
 - `ftp_target_time` (Number) The target time for operation completion. Specified in milliseconds.
 - `ftp_time_limit` (Number) Set the time limit for the test (in seconds). FTP tests default to 10s.
-- `groups` (Block List) The array of label objects. (see [below for nested schema](#nestedblock--groups))
+- `groups` (Block Set) The array of label objects. (see [below for nested schema](#nestedblock--groups))
 - `mtu_measurements` (Boolean) Measure MTU sizes on the network from agents to the target.
 - `network_measurements` (Boolean) Set to 'true' to enable network measurements.
 - `num_path_traces` (Number) The number of path traces.
@@ -70,7 +70,7 @@ Optional:
 - `created_date` (String) The date the agent was created. Expressed in UTC (yyyy-MM-dd hh:mm:ss).
 - `enabled` (Boolean) Shows whether the agent is enabled or disabled.
 - `error_details` (Block List) If one or more errors present in the agent, the error details are shown for each as an array. (see [below for nested schema](#nestedblock--agents--error_details))
-- `groups` (Block List) An array of label objects. (see [below for nested schema](#nestedblock--agents--groups))
+- `groups` (Block Set) An array of label objects. (see [below for nested schema](#nestedblock--agents--groups))
 - `hostname` (String) Fully qualified domain name of the agent.
 - `ip_addresses` (List of String) An array of the ipAddress entries.
 - `ipv6_policy` (String) [FORCE_IPV4, PREFER_IPV6 or FORCE_IPV6] The IP version policy.
@@ -118,7 +118,7 @@ Optional:
 
 Optional:
 
-- `builtin` (Number) Shows whether you are using built-in (1) labels or user-created (2) labels. Built-in labels are read-only.
+- `builtin` (Boolean) Shows whether you are using built-in (1) labels or user-created (2) labels. Built-in labels are read-only.
 - `group_id` (Number) The unique ID of the label. This number is negative for built-in labels. Query the /groups/{id} endpoint to see a list of agents/tests with this label.
 - `name` (String) The name of the label.
 - `type` (String) [tests, agents, endpoint_tests or endpoint_agents] The type of label.

--- a/docs/resources/http_server.md
+++ b/docs/resources/http_server.md
@@ -51,7 +51,7 @@ resource "thousandeyes_http_server" "example_http_server_test" {
 - `download_limit` (Number) Specify the maximum number of bytes to download from the target object.
 - `enabled` (Boolean) Enables or disables the test.
 - `follow_redirects` (Boolean) Follow HTTP/301 or HTTP/302 redirect directives. Defaults to 'true'.
-- `groups` (Block List) The array of label objects. (see [below for nested schema](#nestedblock--groups))
+- `groups` (Block Set) The array of label objects. (see [below for nested schema](#nestedblock--groups))
 - `headers` (List of String) ["header: value", "header2: value"] The array of header strings.
 - `http_target_time` (Number) The target time for HTTP server completion, specified in milliseconds.
 - `http_time_limit` (Number) The target time for HTTP server limits, specified in seconds.
@@ -98,7 +98,7 @@ Optional:
 - `created_date` (String) The date the agent was created. Expressed in UTC (yyyy-MM-dd hh:mm:ss).
 - `enabled` (Boolean) Shows whether the agent is enabled or disabled.
 - `error_details` (Block List) If one or more errors present in the agent, the error details are shown for each as an array. (see [below for nested schema](#nestedblock--agents--error_details))
-- `groups` (Block List) An array of label objects. (see [below for nested schema](#nestedblock--agents--groups))
+- `groups` (Block Set) An array of label objects. (see [below for nested schema](#nestedblock--agents--groups))
 - `hostname` (String) Fully qualified domain name of the agent.
 - `ip_addresses` (List of String) An array of the ipAddress entries.
 - `ipv6_policy` (String) [FORCE_IPV4, PREFER_IPV6 or FORCE_IPV6] The IP version policy.
@@ -146,7 +146,7 @@ Optional:
 
 Optional:
 
-- `builtin` (Number) Shows whether you are using built-in (1) labels or user-created (2) labels. Built-in labels are read-only.
+- `builtin` (Boolean) Shows whether you are using built-in (1) labels or user-created (2) labels. Built-in labels are read-only.
 - `group_id` (Number) The unique ID of the label. This number is negative for built-in labels. Query the /groups/{id} endpoint to see a list of agents/tests with this label.
 - `name` (String) The name of the label.
 - `type` (String) [tests, agents, endpoint_tests or endpoint_agents] The type of label.

--- a/docs/resources/label.md
+++ b/docs/resources/label.md
@@ -51,7 +51,7 @@ Optional:
 - `alerts_enabled` (Boolean) Set to 'true' to enable alerts, or 'false' to disable alerts. The default value is 'true'.
 - `description` (String) A description of the alert rule. Defaults to an empty string.
 - `enabled` (Boolean) Enables or disables the test.
-- `groups` (Block List) The array of label objects. (see [below for nested schema](#nestedblock--tests--groups))
+- `groups` (Block Set) The array of label objects. (see [below for nested schema](#nestedblock--tests--groups))
 - `shared_with_accounts` (Block List) [“serverName”: “fqdn of server”] The array of DNS Server objects. (see [below for nested schema](#nestedblock--tests--shared_with_accounts))
 
 Read-Only:
@@ -78,7 +78,7 @@ Optional:
 - `created_date` (String) The date the agent was created. Expressed in UTC (yyyy-MM-dd hh:mm:ss).
 - `enabled` (Boolean) Shows whether the agent is enabled or disabled.
 - `error_details` (Block List) If one or more errors present in the agent, the error details are shown for each as an array. (see [below for nested schema](#nestedblock--tests--agents--error_details))
-- `groups` (Block List) An array of label objects. (see [below for nested schema](#nestedblock--tests--agents--groups))
+- `groups` (Block Set) An array of label objects. (see [below for nested schema](#nestedblock--tests--agents--groups))
 - `hostname` (String) Fully qualified domain name of the agent.
 - `ip_addresses` (List of String) An array of the ipAddress entries.
 - `ipv6_policy` (String) [FORCE_IPV4, PREFER_IPV6 or FORCE_IPV6] The IP version policy.
@@ -126,7 +126,7 @@ Optional:
 
 Optional:
 
-- `builtin` (Number) Shows whether you are using built-in (1) labels or user-created (2) labels. Built-in labels are read-only.
+- `builtin` (Boolean) Shows whether you are using built-in (1) labels or user-created (2) labels. Built-in labels are read-only.
 - `group_id` (Number) The unique ID of the label. This number is negative for built-in labels. Query the /groups/{id} endpoint to see a list of agents/tests with this label.
 - `name` (String) The name of the label.
 - `type` (String) [tests, agents, endpoint_tests or endpoint_agents] The type of label.

--- a/docs/resources/page_load.md
+++ b/docs/resources/page_load.md
@@ -49,7 +49,7 @@ resource "thousandeyes_page_load" "test" {
 - `description` (String) A description of the alert rule. Defaults to an empty string.
 - `enabled` (Boolean) Enables or disables the test.
 - `follow_redirects` (Boolean) Follow HTTP/301 or HTTP/302 redirect directives. Defaults to 'true'.
-- `groups` (Block List) The array of label objects. (see [below for nested schema](#nestedblock--groups))
+- `groups` (Block Set) The array of label objects. (see [below for nested schema](#nestedblock--groups))
 - `http_target_time` (Number) The target time for HTTP server completion, specified in milliseconds.
 - `http_time_limit` (Number) The target time for HTTP server limits, specified in seconds.
 - `http_version` (Number) Set to 2 for the default HTTP version (prefer HTTP/2), or 1 for HTTP/1.1 only.
@@ -99,7 +99,7 @@ Optional:
 - `created_date` (String) The date the agent was created. Expressed in UTC (yyyy-MM-dd hh:mm:ss).
 - `enabled` (Boolean) Shows whether the agent is enabled or disabled.
 - `error_details` (Block List) If one or more errors present in the agent, the error details are shown for each as an array. (see [below for nested schema](#nestedblock--agents--error_details))
-- `groups` (Block List) An array of label objects. (see [below for nested schema](#nestedblock--agents--groups))
+- `groups` (Block Set) An array of label objects. (see [below for nested schema](#nestedblock--agents--groups))
 - `hostname` (String) Fully qualified domain name of the agent.
 - `ip_addresses` (List of String) An array of the ipAddress entries.
 - `ipv6_policy` (String) [FORCE_IPV4, PREFER_IPV6 or FORCE_IPV6] The IP version policy.
@@ -147,7 +147,7 @@ Optional:
 
 Optional:
 
-- `builtin` (Number) Shows whether you are using built-in (1) labels or user-created (2) labels. Built-in labels are read-only.
+- `builtin` (Boolean) Shows whether you are using built-in (1) labels or user-created (2) labels. Built-in labels are read-only.
 - `group_id` (Number) The unique ID of the label. This number is negative for built-in labels. Query the /groups/{id} endpoint to see a list of agents/tests with this label.
 - `name` (String) The name of the label.
 - `type` (String) [tests, agents, endpoint_tests or endpoint_agents] The type of label.

--- a/docs/resources/sip_server.md
+++ b/docs/resources/sip_server.md
@@ -47,7 +47,7 @@ resource "thousandeyes_sip_server" "example_sip_server_test" {
 - `bgp_measurements` (Boolean) Enable BGP measurements. Set to true for enabled, false for disabled.
 - `description` (String) A description of the alert rule. Defaults to an empty string.
 - `enabled` (Boolean) Enables or disables the test.
-- `groups` (Block List) The array of label objects. (see [below for nested schema](#nestedblock--groups))
+- `groups` (Block Set) The array of label objects. (see [below for nested schema](#nestedblock--groups))
 - `mtu_measurements` (Boolean) Measure MTU sizes on the network from agents to the target.
 - `network_measurements` (Boolean) Set to 'true' to enable network measurements.
 - `num_path_traces` (Number) The number of path traces.
@@ -86,7 +86,7 @@ Optional:
 - `created_date` (String) The date the agent was created. Expressed in UTC (yyyy-MM-dd hh:mm:ss).
 - `enabled` (Boolean) Shows whether the agent is enabled or disabled.
 - `error_details` (Block List) If one or more errors present in the agent, the error details are shown for each as an array. (see [below for nested schema](#nestedblock--agents--error_details))
-- `groups` (Block List) An array of label objects. (see [below for nested schema](#nestedblock--agents--groups))
+- `groups` (Block Set) An array of label objects. (see [below for nested schema](#nestedblock--agents--groups))
 - `hostname` (String) Fully qualified domain name of the agent.
 - `ip_addresses` (List of String) An array of the ipAddress entries.
 - `ipv6_policy` (String) [FORCE_IPV4, PREFER_IPV6 or FORCE_IPV6] The IP version policy.
@@ -134,7 +134,7 @@ Optional:
 
 Optional:
 
-- `builtin` (Number) Shows whether you are using built-in (1) labels or user-created (2) labels. Built-in labels are read-only.
+- `builtin` (Boolean) Shows whether you are using built-in (1) labels or user-created (2) labels. Built-in labels are read-only.
 - `group_id` (Number) The unique ID of the label. This number is negative for built-in labels. Query the /groups/{id} endpoint to see a list of agents/tests with this label.
 - `name` (String) The name of the label.
 - `type` (String) [tests, agents, endpoint_tests or endpoint_agents] The type of label.

--- a/docs/resources/voice.md
+++ b/docs/resources/voice.md
@@ -48,7 +48,7 @@ resource "thousandeyes_voice" "example_voice_test" {
 - `dscp_id` (Number) The DSCP ID.
 - `duration` (Number) The duration of the test, in seconds (5 to 30).
 - `enabled` (Boolean) Enables or disables the test.
-- `groups` (Block List) The array of label objects. (see [below for nested schema](#nestedblock--groups))
+- `groups` (Block Set) The array of label objects. (see [below for nested schema](#nestedblock--groups))
 - `jitter_buffer` (Number) The de-jitter buffer size, in seconds (0 to 150).
 - `mtu_measurements` (Boolean) Measure MTU sizes on the network from agents to the target.
 - `num_path_traces` (Number) The number of path traces.
@@ -83,7 +83,7 @@ Optional:
 - `created_date` (String) The date the agent was created. Expressed in UTC (yyyy-MM-dd hh:mm:ss).
 - `enabled` (Boolean) Shows whether the agent is enabled or disabled.
 - `error_details` (Block List) If one or more errors present in the agent, the error details are shown for each as an array. (see [below for nested schema](#nestedblock--agents--error_details))
-- `groups` (Block List) An array of label objects. (see [below for nested schema](#nestedblock--agents--groups))
+- `groups` (Block Set) An array of label objects. (see [below for nested schema](#nestedblock--agents--groups))
 - `hostname` (String) Fully qualified domain name of the agent.
 - `ip_addresses` (List of String) An array of the ipAddress entries.
 - `ipv6_policy` (String) [FORCE_IPV4, PREFER_IPV6 or FORCE_IPV6] The IP version policy.
@@ -131,7 +131,7 @@ Optional:
 
 Optional:
 
-- `builtin` (Number) Shows whether you are using built-in (1) labels or user-created (2) labels. Built-in labels are read-only.
+- `builtin` (Boolean) Shows whether you are using built-in (1) labels or user-created (2) labels. Built-in labels are read-only.
 - `group_id` (Number) The unique ID of the label. This number is negative for built-in labels. Query the /groups/{id} endpoint to see a list of agents/tests with this label.
 - `name` (String) The name of the label.
 - `type` (String) [tests, agents, endpoint_tests or endpoint_agents] The type of label.

--- a/docs/resources/web_transaction.md
+++ b/docs/resources/web_transaction.md
@@ -33,7 +33,7 @@ This resource allows users to create a transaction test. This test type is a scr
 - `description` (String) A description of the alert rule. Defaults to an empty string.
 - `desired_status_code` (String) The valid HTTP response code you’re interested in retrieving.
 - `enabled` (Boolean) Enables or disables the test.
-- `groups` (Block List) The array of label objects. (see [below for nested schema](#nestedblock--groups))
+- `groups` (Block Set) The array of label objects. (see [below for nested schema](#nestedblock--groups))
 - `http_target_time` (Number) The target time for HTTP server completion, specified in milliseconds.
 - `http_time_limit` (Number) The target time for HTTP server limits, specified in seconds.
 - `http_version` (Number) Set to 2 for the default HTTP version (prefer HTTP/2), or 1 for HTTP/1.1 only.
@@ -81,7 +81,7 @@ Optional:
 - `created_date` (String) The date the agent was created. Expressed in UTC (yyyy-MM-dd hh:mm:ss).
 - `enabled` (Boolean) Shows whether the agent is enabled or disabled.
 - `error_details` (Block List) If one or more errors present in the agent, the error details are shown for each as an array. (see [below for nested schema](#nestedblock--agents--error_details))
-- `groups` (Block List) An array of label objects. (see [below for nested schema](#nestedblock--agents--groups))
+- `groups` (Block Set) An array of label objects. (see [below for nested schema](#nestedblock--agents--groups))
 - `hostname` (String) Fully qualified domain name of the agent.
 - `ip_addresses` (List of String) An array of the ipAddress entries.
 - `ipv6_policy` (String) [FORCE_IPV4, PREFER_IPV6 or FORCE_IPV6] The IP version policy.
@@ -129,7 +129,7 @@ Optional:
 
 Optional:
 
-- `builtin` (Number) Shows whether you are using built-in (1) labels or user-created (2) labels. Built-in labels are read-only.
+- `builtin` (Boolean) Shows whether you are using built-in (1) labels or user-created (2) labels. Built-in labels are read-only.
 - `group_id` (Number) The unique ID of the label. This number is negative for built-in labels. Query the /groups/{id} endpoint to see a list of agents/tests with this label.
 - `name` (String) The name of the label.
 - `type` (String) [tests, agents, endpoint_tests or endpoint_agents] The type of label.

--- a/thousandeyes/schemas.go
+++ b/thousandeyes/schemas.go
@@ -171,13 +171,13 @@ var schemas = map[string]*schema.Schema{
 					},
 				},
 				"groups": {
-					Type:        schema.TypeList,
+					Type:        schema.TypeSet,
 					Description: "An array of label objects.",
 					Optional:    true,
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
 							"builtin": {
-								Type:        schema.TypeInt,
+								Type:        schema.TypeBool,
 								Description: "Shows whether you are using built-in (1) labels or user-created (2) labels. Built-in labels are read-only.",
 								Optional:    true,
 							},
@@ -190,11 +190,13 @@ var schemas = map[string]*schema.Schema{
 								Type:        schema.TypeString,
 								Description: "The name of the label.",
 								Optional:    true,
+								Default:     "",
 							},
 							"type": {
 								Type:        schema.TypeString,
 								Description: "[tests, agents, endpoint_tests or endpoint_agents] The type of label.",
 								Optional:    true,
+								Default:     "",
 							},
 						},
 					},
@@ -589,7 +591,7 @@ var schemas = map[string]*schema.Schema{
 		ValidateFunc: validation.IntBetween(10, 60),
 	},
 	"groups": {
-		Type:        schema.TypeList,
+		Type:        schema.TypeSet,
 		Description: "The array of label objects.",
 		Optional:    true,
 		Elem: &schema.Resource{
@@ -625,6 +627,7 @@ var schemas = map[string]*schema.Schema{
 					Type:        schema.TypeString,
 					Description: "The name of the label.",
 					Optional:    true,
+					Default:     "",
 				},
 				"tests": {
 					Type:        schema.TypeList,
@@ -645,6 +648,7 @@ var schemas = map[string]*schema.Schema{
 					Type:        schema.TypeString,
 					Description: "[tests, agents, endpoint_tests, or endpoint_agents] The type of label.",
 					Optional:    true,
+					Default:     "",
 				},
 			},
 		},


### PR DESCRIPTION
Additionally fixes type of builtin field in the agent groups (it was causing the provider to crash `panic: reflect.Set: value of type int is not assignable to type bool`).

This fixes https://github.com/thousandeyes/terraform-provider-thousandeyes/issues/105

TypeList is an ordered list, but users shouldn't have to worry about the order in which group blocks are placed in the resource:

```hcl
resource "thousandeyes_agent_to_server" "example" {
  test_name      = "example"
  interval       = 120
  alerts_enabled = false
  use_public_bgp = false
  enabled = false

  server = "www.thousandeyes.com"

  agents {
    agent_id = 1234
  }

  groups {
    group_id = 1234
  }

  groups {
    group_id = 5678
  }
}
```

With `typeList`, terraform will care about the order of the groups, but with `typeSet`, order is not important (it's also a set meaning items can't be repeated, which applies here). 

Additionally, the default value for `type` and `name` should be an empty string. We're sending `null` and storing that in the state, but then on the next terraform plan, the API will send empty strings in `type` and `name`. Terraform will compare that to the `null`s in the state and think that there were outside changes made to the resource. If we send empty strings as default, this no longer happens.

My local tests show that this works as expected and terraform won't try to change the order on every run. 

Unit tests pass:
```
?   	github.com/thousandeyes/terraform-provider-thousandeyes	[no test files]
ok  	github.com/thousandeyes/terraform-provider-thousandeyes/thousandeyes	0.480s
```