### PR TITLE
feat: allows overriding the API Endpoint

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -53,6 +53,7 @@ resource "thousandeyes_http_server" "www_thousandeyes_http_test" {
 ### Optional
 
 - `account_group_id` (String) The ThousandEyes account group's unique ID.
+- `api_endpoint` (String) The ThousandEyes API Endpoint's URL. E.g. https://api.thousandeyes.com/v6
 - `timeout` (Number) The timeout value.
 
 Account group IDs can be retrieved from the API by querying the `/v6/account-groups` endpoint. For more information, check the

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/hashicorp/terraform-plugin-docs v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.17.0
-	github.com/thousandeyes/thousandeyes-sdk-go/v2 v2.1.0
+	github.com/thousandeyes/thousandeyes-sdk-go/v2 v2.3.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -260,8 +260,8 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.2 h1:4jaiDzPyXQvSd7D0EjG45355tLlV3VOECpq10pLC+8s=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
-github.com/thousandeyes/thousandeyes-sdk-go/v2 v2.1.0 h1:0tR78mOjX3bccfcnerb6x0adp0fX5sJJK0QOXSmIgLA=
-github.com/thousandeyes/thousandeyes-sdk-go/v2 v2.1.0/go.mod h1:XQouPCy3dIp81Xzkp9bqu6vg7fmE4QQpA6REsLVTDdE=
+github.com/thousandeyes/thousandeyes-sdk-go/v2 v2.3.0 h1:uEkpjBj1KaSzNgaeh1MWT7cUEdAq43NjP0pZKtJvsmk=
+github.com/thousandeyes/thousandeyes-sdk-go/v2 v2.3.0/go.mod h1:XQouPCy3dIp81Xzkp9bqu6vg7fmE4QQpA6REsLVTDdE=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/thousandeyes/provider.go
+++ b/thousandeyes/provider.go
@@ -41,6 +41,12 @@ func Provider() *schema.Provider {
 				DefaultFunc: schema.EnvDefaultFunc("TE_TIMEOUT", 0),
 				Description: "The timeout value.",
 			},
+			"api_endpoint": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("TE_API_ENDPOINT", "https://api.thousandeyes.com/v6"),
+				Description: "The ThousandEyes API Endpoint's URL. E.g. https://api.thousandeyes.com/v6",
+			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"thousandeyes_alert_rule":      resourceAlertRule(),
@@ -71,10 +77,11 @@ func Provider() *schema.Provider {
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	log.Println("[INFO] Initializing ThousandEyes client")
 	opts := thousandeyes.ClientOptions{
-		AuthToken: d.Get("token").(string),
-		AccountID: d.Get("account_group_id").(string),
-		Timeout:   time.Second * time.Duration(d.Get("timeout").(int)),
-		UserAgent: "ThousandEyes Terraform Provider",
+		AuthToken:   d.Get("token").(string),
+		AccountID:   d.Get("account_group_id").(string),
+		Timeout:     time.Second * time.Duration(d.Get("timeout").(int)),
+		UserAgent:   "ThousandEyes Terraform Provider",
+		APIEndpoint: d.Get("api_endpoint").(string),
 	}
 	var err error
 	if opts.AccountID != "" {


### PR DESCRIPTION
```
go vet ./... && echo && go test ./...

?   	github.com/thousandeyes/terraform-provider-thousandeyes	[no test files]
ok  	github.com/thousandeyes/terraform-provider-thousandeyes/thousandeyes	0.434s
```

Tested while working on the PR for the Go SDK:

Tested locally without overriding:
```
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - thousandeyes/thousandeyes in /Users/pedrorg/go/bin
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
thousandeyes_alert_rule.test_alert_rule: Refreshing state... [id=4946549]
thousandeyes_agent_to_server.thousandeyes_agent_to_server_tcp_no_port: Refreshing state... [id=3113616]
thousandeyes_dns_server.example_dns_server_test: Refreshing state... [id=3027162]
thousandeyes_agent_to_agent.example_agent_to_agent: Refreshing state... [id=3026866]
thousandeyes_label.tf: Refreshing state... [id=410351]
thousandeyes_alert_rule.thousandeyes_alert_rule_slack: Refreshing state... [id=5009877]
thousandeyes_sip_server.sip_server_example: Refreshing state... [id=3026862]
thousandeyes_agent_to_server.thousandeyes_agent_to_server_icmp_test: Refreshing state... [id=3113617]
thousandeyes_agent_to_server.google_agent_to_server: Refreshing state... [id=3026865]
thousandeyes_alert_rule.test_alert_rule-2: Refreshing state... [id=4946550]
thousandeyes_voice.webex_rtp_example: Refreshing state... [id=3026905]
thousandeyes_page_load.test: Refreshing state... [id=3026863]
thousandeyes_http_server.www_thousandeyes_http_test: Refreshing state... [id=3026864]

No changes. Your infrastructure matches the configuration.
```

And with overrides (of course it fails):
```
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - thousandeyes/thousandeyes in /Users/pedrorg/go/bin
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
thousandeyes_alert_rule.test_alert_rule: Refreshing state... [id=4946549]
thousandeyes_agent_to_server.thousandeyes_agent_to_server_tcp_no_port: Refreshing state... [id=3113616]
thousandeyes_agent_to_server.thousandeyes_agent_to_server_icmp_test: Refreshing state... [id=3113617]
thousandeyes_agent_to_server.google_agent_to_server: Refreshing state... [id=3026865]
thousandeyes_label.tf: Refreshing state... [id=410351]
thousandeyes_dns_server.example_dns_server_test: Refreshing state... [id=3027162]
thousandeyes_agent_to_agent.example_agent_to_agent: Refreshing state... [id=3026866]
thousandeyes_sip_server.sip_server_example: Refreshing state... [id=3026862]
thousandeyes_alert_rule.test_alert_rule-2: Refreshing state... [id=4946550]
thousandeyes_alert_rule.thousandeyes_alert_rule_slack: Refreshing state... [id=5009877]
╷
│ Error: Get "https://api.millioneyes.com/v9/agents.json?aid=69": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
│
│   with data.thousandeyes_agent.arg_cordoba,
│   on main.tf line 1, in data "thousandeyes_agent" "arg_cordoba":
│    1: data "thousandeyes_agent" "arg_cordoba" {
│
╵
╷
│ Error: Get "https://api.millioneyes.com/v9/agents.json?aid=69": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
│
│   with data.thousandeyes_agent.arg_bsas,
│   on main.tf line 5, in data "thousandeyes_agent" "arg_bsas":
│    5: data "thousandeyes_agent" "arg_bsas" {
```

Note that this is jumping intentionally from `2.1.0` to `2.3.0`. `2.2.0` includes the recent updates made to support `Third Party` notifications on alert rules in the Go SDK. `2.3.0` includes these changes too. They are harmless as the support for `Third Party` notifications still needs to be implemented in the terraform provider, it only exists in the Go SDK atm. 