### PR TITLE
feat: Implement third party notification support within alert rules

### DIFF
--- a/docs/resources/alert_rule.md
+++ b/docs/resources/alert_rule.md
@@ -45,6 +45,7 @@ This resource allows you to create alert rules for ThousandEyes alerts. Alert ru
 Optional:
 
 - `email` (Block Set) The email notification. (see [below for nested schema](#nestedblock--notifications--email))
+- `third_party` (Block Set) Third party notification. (see [below for nested schema](#nestedblock--notifications--third_party))
 
 <a id="nestedblock--notifications--email"></a>
 ### Nested Schema for `notifications.email`
@@ -53,5 +54,14 @@ Optional:
 
 - `message` (String) The contents of the email, as a string.
 - `recipient` (List of String) The email addresses to send the notification to.
+
+
+<a id="nestedblock--notifications--third_party"></a>
+### Nested Schema for `notifications.third_party`
+
+Required:
+
+- `integration_id` (String) The integration ID, as a string.
+- `integration_type` (String) The integration type, as a string.
 
 

--- a/thousandeyes/schemas.go
+++ b/thousandeyes/schemas.go
@@ -815,6 +815,25 @@ var schemas = map[string]*schema.Schema{
 						},
 					},
 				},
+				"third_party": {
+					Type:        schema.TypeSet,
+					Description: "Third party notification.",
+					Optional:    true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"integration_id": {
+								Type:        schema.TypeString,
+								Description: "The integration ID, as a string.",
+								Required:    true,
+							},
+							"integration_type": {
+								Type:        schema.TypeString,
+								Description: "The integration type, as a string.",
+								Required:    true,
+							},
+						},
+					},
+				},
 			},
 		},
 	},

--- a/thousandeyes/util_test.go
+++ b/thousandeyes/util_test.go
@@ -238,7 +238,7 @@ func TestFixReadValues(t *testing.T) {
 	}
 	output, err = FixReadValues(groupsInput, "groups")
 	if err != nil {
-		t.Errorf("bgp_monitors input returned error: %s", err.Error())
+		t.Errorf("groups input returned error: %s", err.Error())
 	}
 	if reflect.DeepEqual(output, groupsTarget) != true {
 		t.Errorf("Values not stripped correctly from groups input: Received %#v Expected %#v", output, groupsTarget)
@@ -325,6 +325,40 @@ func TestFixReadValues(t *testing.T) {
 		t.Errorf("Values not stripped correctly from tests input: Received %#v Expected %#v", output, nil)
 	}
 
+	// thirdParty notifications
+	thirdPartyNotificationsInput := []interface{}{
+		map[string]interface{}{
+			"integration_id":   "sl-0000",
+			"integration_type": "SLACK",
+			"integration_name": "bitconnect",
+			"target":           "https://slack.com/waso",
+			"channel":          "#terraform",
+		},
+		map[string]interface{}{
+			"integration_id":   "pgd-0000",
+			"integration_type": "PAGER_DUTY",
+			"integration_name": "PagerDuty notification",
+			"auth_method":      "Auth Token",
+		},
+	}
+	thirdPartyNotificationsTarget := []interface{}{
+		map[string]interface{}{
+			"integration_id":   "sl-0000",
+			"integration_type": "SLACK",
+		},
+		map[string]interface{}{
+			"integration_id":   "pgd-0000",
+			"integration_type": "PAGER_DUTY",
+		},
+	}
+
+	output, err = FixReadValues(thirdPartyNotificationsInput, "third_party")
+	if err != nil {
+		t.Errorf("third party notifications input returned error: %s", err.Error())
+	}
+	if reflect.DeepEqual(output, thirdPartyNotificationsTarget) != true {
+		t.Errorf("Values not stripped correctly from third party notifications input: Received %#v Expected %#v", output, thirdPartyNotificationsTarget)
+	}
 }
 
 func TestResourceUpdate(t *testing.T) {


### PR DESCRIPTION
This adds support for third party notifications within alert rules. This functionality was added to the Go SDK by a customer and external contributor, and we're adding the support to the terraform provider as it was a bit more complex than adding the support to the Go SDK. 

Tests are ok:
```
go vet ./... && echo && go test ./...

?   	github.com/thousandeyes/terraform-provider-thousandeyes	[no test files]
ok  	github.com/thousandeyes/terraform-provider-thousandeyes/thousandeyes	0.279s
```

Tested the provider with a local override:
```hcl
resource "thousandeyes_alert_rule" "thousandeyes_alert_rule_slack" {
  rule_name = "Pedro-test: Alert Rule with third party integration"
  alert_type = "End-to-End (Server)"
  expression = "((loss >= 10%))"
  minimum_sources = 5
  rounds_violating_required = 10
  rounds_violating_out_of = 10
  rounds_violating_mode = "ANY"
  notifications {
    email {
      message = "Pedro-test"
      recipient = ["pedro@bitconnect.net"]
    }

    third_party {
      integration_id = "sl-8026"
      integration_type = "SLACK"
    }

    third_party {
      integration_id = "pgd-5866"
      integration_type = "PAGER_DUTY"
    }
  }
}
```

terraform plan and apply:
```
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - thousandeyes/thousandeyes in /Users/pedrorg/go/bin
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
thousandeyes_agent_to_server.google_agent_to_server: Refreshing state... [id=3026865]
thousandeyes_alert_rule.thousandeyes_alert_rule_slack: Refreshing state... [id=5009877]
thousandeyes_label.tf: Refreshing state... [id=410351]
thousandeyes_agent_to_agent.example_agent_to_agent: Refreshing state... [id=3026866]
thousandeyes_agent_to_server.thousandeyes_agent_to_server_tcp_no_port: Refreshing state... [id=3113616]
thousandeyes_sip_server.sip_server_example: Refreshing state... [id=3026862]
thousandeyes_alert_rule.test_alert_rule-2: Refreshing state... [id=4946550]
thousandeyes_alert_rule.test_alert_rule: Refreshing state... [id=4946549]
thousandeyes_dns_server.example_dns_server_test: Refreshing state... [id=3027162]
thousandeyes_agent_to_server.thousandeyes_agent_to_server_icmp_test: Refreshing state... [id=3113617]
thousandeyes_voice.webex_rtp_example: Refreshing state... [id=3026905]
thousandeyes_page_load.test: Refreshing state... [id=3026863]
thousandeyes_http_server.www_thousandeyes_http_test: Refreshing state... [id=3026864]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # thousandeyes_alert_rule.thousandeyes_alert_rule_slack will be updated in-place
  ~ resource "thousandeyes_alert_rule" "thousandeyes_alert_rule_slack" {
        id                        = "5009877"
        # (10 unchanged attributes hidden)

      + notifications {
          + email {
              + message   = "Pedro-test"
              + recipient = [
                  + "pedro@bitconnect.net",
                ]
            }

          + third_party {
              + integration_id   = "pgd-5866"
              + integration_type = "PAGER_DUTY"
            }
          + third_party {
              + integration_id   = "sl-8026"
              + integration_type = "SLACK"
            }
        }
      - notifications {
          - email {
              - message   = "Pedro-test" -> null
              - recipient = [
                  - "pedro@bitconnect.net",
                ] -> null
            }
        }
    }

Plan: 0 to add, 1 to change, 0 to destroy.
(...)
thousandeyes_alert_rule.thousandeyes_alert_rule_slack: Modifying... [id=5009877]
thousandeyes_alert_rule.thousandeyes_alert_rule_slack: Modifications complete after 1s [id=5009877]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```

Subsequent plan:
```
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - thousandeyes/thousandeyes in /Users/pedrorg/go/bin
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
thousandeyes_sip_server.sip_server_example: Refreshing state... [id=3026862]
thousandeyes_dns_server.example_dns_server_test: Refreshing state... [id=3027162]
thousandeyes_alert_rule.thousandeyes_alert_rule_slack: Refreshing state... [id=5009877]
thousandeyes_agent_to_agent.example_agent_to_agent: Refreshing state... [id=3026866]
thousandeyes_alert_rule.test_alert_rule-2: Refreshing state... [id=4946550]
thousandeyes_agent_to_server.google_agent_to_server: Refreshing state... [id=3026865]
thousandeyes_agent_to_server.thousandeyes_agent_to_server_icmp_test: Refreshing state... [id=3113617]
thousandeyes_label.tf: Refreshing state... [id=410351]
thousandeyes_alert_rule.test_alert_rule: Refreshing state... [id=4946549]
thousandeyes_agent_to_server.thousandeyes_agent_to_server_tcp_no_port: Refreshing state... [id=3113616]
thousandeyes_page_load.test: Refreshing state... [id=3026863]
thousandeyes_voice.webex_rtp_example: Refreshing state... [id=3026905]
thousandeyes_http_server.www_thousandeyes_http_test: Refreshing state... [id=3026864]

No changes. Your infrastructure matches the configuration.
```

The filtering of the fields inside the `third_party` block stops terraform from wanting to update the `third_party` blocks on every plan because of additional fields that our API returns. 