### PR TITLE
fix: Adding required ThousandEyes integration type

### DIFF
--- a/thousandeyes/data_source_thousandeyes_integration.go
+++ b/thousandeyes/data_source_thousandeyes_integration.go
@@ -95,6 +95,10 @@ func dataSourceThousandeyesIntegrationRead(d *schema.ResourceData, meta interfac
 	if err != nil {
 		return err
 	}
+	err = d.Set("integration_type", found.IntegrationType)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/thousandeyes/data_source_thousandeyes_integration.go
+++ b/thousandeyes/data_source_thousandeyes_integration.go
@@ -86,16 +86,9 @@ func dataSourceThousandeyesIntegrationRead(d *schema.ResourceData, meta interfac
 	if found == (thousandeyes.Integration{}) {
 		return fmt.Errorf("unable to locate any integration by name: %s", searchName)
 	}
+
 	d.SetId(*found.IntegrationID)
-	err = d.Set("integration_name", found.IntegrationName)
-	if err != nil {
-		return err
-	}
-	err = d.Set("integration_id", found.IntegrationID)
-	if err != nil {
-		return err
-	}
-	err = d.Set("integration_type", found.IntegrationType)
+	err = ResourceRead(d, &found)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Hello,

I've tried to setup ThousandEyes integrations and faced the issue:
```
2022-10-17T14:33:59.592-0600 [ERROR] vertex "thousandeyes_alert_rule.external_monitor_alert_rule" error: Missing required argument
2022-10-17T14:33:59.609-0600 [INFO]  backend/local: plan operation completed
╷
│ Error: Missing required argument
│
│   with thousandeyes_alert_rule.external_monitor_alert_rule,
│   on te_alert_rule.tf line 3, in resource "thousandeyes_alert_rule" "external_monitor_alert_rule":
│    3: resource "thousandeyes_alert_rule" "external_monitor_alert_rule" {
│
│ The argument "notifications.0.third_party.0.integration_type" is required,
│ but no definition was found.
```

I've added and successfully tested the missing argument. 
```
...
  # thousandeyes_alert_rule.external_monitor_alert_rule will be created
  + resource "thousandeyes_alert_rule" "external_monitor_alert_rule" {
      + alert_rule_id             = (known after apply)
      + alert_type                = "Web Transactions"

      + notifications {
          + third_party {
              + integration_id   = "pgd-xxxx"
              + integration_type = "PAGER_DUTY"
            }
        }
    }
...
Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + pagerduty_integration_id   = "pgd-xxxx"
  + pagerduty_integration_type = "PAGER_DUTY"
...
```

Please review the proposed fix.