### PR TITLE
fix: fixes bugs related to alert rule notifications

### DIFF
--- a/docs/resources/alert_rule.md
+++ b/docs/resources/alert_rule.md
@@ -53,7 +53,7 @@ Optional:
 Optional:
 
 - `message` (String) The contents of the email, as a string.
-- `recipient` (List of String) The email addresses to send the notification to.
+- `recipient` (Set of String) The email addresses to send the notification to.
 
 
 <a id="nestedblock--notifications--third_party"></a>

--- a/thousandeyes/resource_alert_rule.go
+++ b/thousandeyes/resource_alert_rule.go
@@ -45,27 +45,11 @@ func resourceAlertRuleUpdate(d *schema.ResourceData, m interface{}) error {
 
 	log.Printf("[INFO] Updating ThousandEyes Test %s", d.Id())
 	id, _ := strconv.ParseInt(d.Id(), 10, 64)
-	update := ResourceUpdate(d, &thousandeyes.AlertRule{}).(*thousandeyes.AlertRule)
 	// While most ThousandEyes updates only require updated fields and specifically
-	// disallow some fields on update, Alert Rules actually require a few fields
-	// to be retained on update.
-	// Terraform schema validation should guarantee their existence.
-	update.AlertType = thousandeyes.String(d.Get("alert_type").(string))
-	update.Expression = thousandeyes.String(d.Get("expression").(string))
-
-	// MinimumSources and MinimumSourcesPct are mutually exclusive
-	minimumSources := d.Get("minimum_sources").(int)
-	if minimumSources > 0 {
-		update.MinimumSources = thousandeyes.Int(minimumSources)
-	} else {
-		update.MinimumSourcesPct = thousandeyes.Int(d.Get("minimum_sources_pct").(int))
-	}
-
-	update.RoundsViolatingRequired = thousandeyes.Int(d.Get("rounds_violating_required").(int))
-	update.RoundsViolatingOutOf = thousandeyes.Int(d.Get("rounds_violating_out_of").(int))
-	update.RuleName = thousandeyes.String(d.Get("rule_name").(string))
-
-	_, err := client.UpdateAlertRule(id, *update)
+	// disallow some fields on update, Alert Rules actually require the full list of
+	// fields. Terraform schema validation should guarantee their existence.
+	local := buildAlertRuleStruct(d)
+	_, err := client.UpdateAlertRule(id, *local)
 	if err != nil {
 		return err
 	}

--- a/thousandeyes/schemas.go
+++ b/thousandeyes/schemas.go
@@ -805,7 +805,7 @@ var schemas = map[string]*schema.Schema{
 								Optional:    true,
 							},
 							"recipient": {
-								Type:        schema.TypeList,
+								Type:        schema.TypeSet,
 								Description: "The email addresses to send the notification to.",
 								Optional:    true,
 								Elem: &schema.Schema{

--- a/thousandeyes/util.go
+++ b/thousandeyes/util.go
@@ -311,14 +311,13 @@ func FixReadValues(m interface{}, name string) (interface{}, error) {
 		if e == nil && tp == nil {
 			m = nil
 		} else {
-			if e != nil {
-				m.(map[string]interface{})["email"] = e
-			}
-
+			// Add the third party map to the notifications map if they are present
+			// if they're not configured, then the API doesn't return them at all
 			if tp != nil {
 				m.(map[string]interface{})["third_party"] = tp
 			}
 
+			m.(map[string]interface{})["email"] = e
 			m = []interface{}{
 				m.(map[string]interface{}),
 			}


### PR DESCRIPTION
  * Fixes bug that was preventing the creation of alert rules with third party notifications but without email notification
  * Fixes bug that was causing some fields (such as notifications and notifyOnClear) in alert rules to be reset when updating alert rules
  * Fixes bug that was causing the recipient list to change on every run (it was using an ordered list)

ThousandEyes API documentation states that to update alert rules, the full list of fields must be sent. [Docs](https://developer.thousandeyes.com/v6/alerts/#/alert-rule-edit).

I should also note that while the fix is very simple, debugging these issues (apart from the recipient list order) was not easy and took me a full day basically, because there's still a lot about this codebase that I don't know. 

Tests are passing:

```
go vet ./... && echo && go test ./...

?   	github.com/thousandeyes/terraform-provider-thousandeyes	[no test files]
ok  	github.com/thousandeyes/terraform-provider-thousandeyes/thousandeyes	(cached)
```

Tested the provider locally multiple times. Worked well in my tests, but please let me know if I can make it easier to review this and to verify. 
