### PR TITLE
docs: marks the group/label attribute in tests as deprecated

### DIFF
--- a/docs/resources/agent_to_agent.md
+++ b/docs/resources/agent_to_agent.md
@@ -47,7 +47,7 @@ resource "thousandeyes_agent_to_agent" "example_agent_to_agent_test" {
 - `description` (String) A description of the alert rule. Defaults to an empty string.
 - `dscp_id` (Number) The DSCP ID.
 - `enabled` (Boolean) Enables or disables the test.
-- `groups` (Block Set) The array of label objects. (see [below for nested schema](#nestedblock--groups))
+- `groups` (Block Set, Deprecated) The array of label objects. (see [below for nested schema](#nestedblock--groups))
 - `mss` (Number) The maximum segment size, in bytes. Value can be from 30 to 1400.
 - `mtu_measurements` (Boolean) Measure MTU sizes on the network from agents to the target.
 - `network_measurements` (Boolean) Set to 'true' to enable network measurements.

--- a/docs/resources/agent_to_server.md
+++ b/docs/resources/agent_to_server.md
@@ -45,7 +45,7 @@ resource "thousandeyes_agent_to_server" "example_agent_to_server_test" {
 - `bgp_monitors` (Block List) The array of BGP monitor object IDs. The monitorIDs can be sourced from the /bgp-monitors endpoint. (see [below for nested schema](#nestedblock--bgp_monitors))
 - `description` (String) A description of the alert rule. Defaults to an empty string.
 - `enabled` (Boolean) Enables or disables the test.
-- `groups` (Block Set) The array of label objects. (see [below for nested schema](#nestedblock--groups))
+- `groups` (Block Set, Deprecated) The array of label objects. (see [below for nested schema](#nestedblock--groups))
 - `mtu_measurements` (Boolean) Measure MTU sizes on the network from agents to the target.
 - `network_measurements` (Boolean) Set to 'true' to enable network measurements.
 - `num_path_traces` (Number) The number of path traces.

--- a/docs/resources/bgp.md
+++ b/docs/resources/bgp.md
@@ -35,7 +35,7 @@ resource "thousandeyes_bgp" "example_bgp_test" {
 - `bgp_monitors` (Block List) The array of BGP monitor object IDs. The monitorIDs can be sourced from the /bgp-monitors endpoint. (see [below for nested schema](#nestedblock--bgp_monitors))
 - `description` (String) A description of the alert rule. Defaults to an empty string.
 - `enabled` (Boolean) Enables or disables the test.
-- `groups` (Block Set) The array of label objects. (see [below for nested schema](#nestedblock--groups))
+- `groups` (Block Set, Deprecated) The array of label objects. (see [below for nested schema](#nestedblock--groups))
 - `include_covered_prefixes` (Boolean) Include queries for subprefixes detected under this prefix.
 - `shared_with_accounts` (Block List) [“serverName”: “fqdn of server”] The array of DNS Server objects. (see [below for nested schema](#nestedblock--shared_with_accounts))
 - `use_public_bgp` (Boolean) Enable to automatically add all available Public BGP Monitors to the test.

--- a/docs/resources/dns_server.md
+++ b/docs/resources/dns_server.md
@@ -49,7 +49,7 @@ resource "thousandeyes_dns_server" "example_dns_server_test" {
 - `description` (String) A description of the alert rule. Defaults to an empty string.
 - `dns_transport_protocol` (String) [UDP or TCP] The DNS transport protocol used for DNS requests. Defaults to UDP.
 - `enabled` (Boolean) Enables or disables the test.
-- `groups` (Block Set) The array of label objects. (see [below for nested schema](#nestedblock--groups))
+- `groups` (Block Set, Deprecated) The array of label objects. (see [below for nested schema](#nestedblock--groups))
 - `mtu_measurements` (Boolean) Measure MTU sizes on the network from agents to the target.
 - `network_measurements` (Boolean) Set to 'true' to enable network measurements.
 - `num_path_traces` (Number) The number of path traces.

--- a/docs/resources/dns_trace.md
+++ b/docs/resources/dns_trace.md
@@ -27,7 +27,7 @@ This resource provides users with the ability to create a DNS trace test. This t
 - `description` (String) A description of the alert rule. Defaults to an empty string.
 - `dns_transport_protocol` (String) [UDP or TCP] The DNS transport protocol used for DNS requests. Defaults to UDP.
 - `enabled` (Boolean) Enables or disables the test.
-- `groups` (Block Set) The array of label objects. (see [below for nested schema](#nestedblock--groups))
+- `groups` (Block Set, Deprecated) The array of label objects. (see [below for nested schema](#nestedblock--groups))
 - `shared_with_accounts` (Block List) [“serverName”: “fqdn of server”] The array of DNS Server objects. (see [below for nested schema](#nestedblock--shared_with_accounts))
 
 ### Read-Only

--- a/docs/resources/dnssec.md
+++ b/docs/resources/dnssec.md
@@ -26,7 +26,7 @@ This resource allows you to create a DNSSEC test. This test type verifies the di
 - `alerts_enabled` (Boolean) Set to 'true' to enable alerts, or 'false' to disable alerts. The default value is 'true'.
 - `description` (String) A description of the alert rule. Defaults to an empty string.
 - `enabled` (Boolean) Enables or disables the test.
-- `groups` (Block Set) The array of label objects. (see [below for nested schema](#nestedblock--groups))
+- `groups` (Block Set, Deprecated) The array of label objects. (see [below for nested schema](#nestedblock--groups))
 - `shared_with_accounts` (Block List) [“serverName”: “fqdn of server”] The array of DNS Server objects. (see [below for nested schema](#nestedblock--shared_with_accounts))
 
 ### Read-Only

--- a/docs/resources/ftp_server.md
+++ b/docs/resources/ftp_server.md
@@ -33,7 +33,7 @@ This resource allows you to create an FTP server test. This test type verifies t
 - `enabled` (Boolean) Enables or disables the test.
 - `ftp_target_time` (Number) The target time for operation completion. Specified in milliseconds.
 - `ftp_time_limit` (Number) Set the time limit for the test (in seconds). FTP tests default to 10s.
-- `groups` (Block Set) The array of label objects. (see [below for nested schema](#nestedblock--groups))
+- `groups` (Block Set, Deprecated) The array of label objects. (see [below for nested schema](#nestedblock--groups))
 - `mtu_measurements` (Boolean) Measure MTU sizes on the network from agents to the target.
 - `network_measurements` (Boolean) Set to 'true' to enable network measurements.
 - `num_path_traces` (Number) The number of path traces.

--- a/docs/resources/http_server.md
+++ b/docs/resources/http_server.md
@@ -51,7 +51,7 @@ resource "thousandeyes_http_server" "example_http_server_test" {
 - `download_limit` (Number) Specify the maximum number of bytes to download from the target object.
 - `enabled` (Boolean) Enables or disables the test.
 - `follow_redirects` (Boolean) Follow HTTP/301 or HTTP/302 redirect directives. Defaults to 'true'.
-- `groups` (Block Set) The array of label objects. (see [below for nested schema](#nestedblock--groups))
+- `groups` (Block Set, Deprecated) The array of label objects. (see [below for nested schema](#nestedblock--groups))
 - `headers` (List of String) ["header: value", "header2: value"] The array of header strings.
 - `http_target_time` (Number) The target time for HTTP server completion, specified in milliseconds.
 - `http_time_limit` (Number) The target time for HTTP server limits, specified in seconds.

--- a/docs/resources/label.md
+++ b/docs/resources/label.md
@@ -51,7 +51,7 @@ Optional:
 - `alerts_enabled` (Boolean) Set to 'true' to enable alerts, or 'false' to disable alerts. The default value is 'true'.
 - `description` (String) A description of the alert rule. Defaults to an empty string.
 - `enabled` (Boolean) Enables or disables the test.
-- `groups` (Block Set) The array of label objects. (see [below for nested schema](#nestedblock--tests--groups))
+- `groups` (Block Set, Deprecated) The array of label objects. (see [below for nested schema](#nestedblock--tests--groups))
 - `shared_with_accounts` (Block List) [“serverName”: “fqdn of server”] The array of DNS Server objects. (see [below for nested schema](#nestedblock--tests--shared_with_accounts))
 
 Read-Only:

--- a/docs/resources/page_load.md
+++ b/docs/resources/page_load.md
@@ -49,7 +49,7 @@ resource "thousandeyes_page_load" "test" {
 - `description` (String) A description of the alert rule. Defaults to an empty string.
 - `enabled` (Boolean) Enables or disables the test.
 - `follow_redirects` (Boolean) Follow HTTP/301 or HTTP/302 redirect directives. Defaults to 'true'.
-- `groups` (Block Set) The array of label objects. (see [below for nested schema](#nestedblock--groups))
+- `groups` (Block Set, Deprecated) The array of label objects. (see [below for nested schema](#nestedblock--groups))
 - `http_target_time` (Number) The target time for HTTP server completion, specified in milliseconds.
 - `http_time_limit` (Number) The target time for HTTP server limits, specified in seconds.
 - `http_version` (Number) Set to 2 for the default HTTP version (prefer HTTP/2), or 1 for HTTP/1.1 only.

--- a/docs/resources/sip_server.md
+++ b/docs/resources/sip_server.md
@@ -47,7 +47,7 @@ resource "thousandeyes_sip_server" "example_sip_server_test" {
 - `bgp_measurements` (Boolean) Enable BGP measurements. Set to true for enabled, false for disabled.
 - `description` (String) A description of the alert rule. Defaults to an empty string.
 - `enabled` (Boolean) Enables or disables the test.
-- `groups` (Block Set) The array of label objects. (see [below for nested schema](#nestedblock--groups))
+- `groups` (Block Set, Deprecated) The array of label objects. (see [below for nested schema](#nestedblock--groups))
 - `mtu_measurements` (Boolean) Measure MTU sizes on the network from agents to the target.
 - `network_measurements` (Boolean) Set to 'true' to enable network measurements.
 - `num_path_traces` (Number) The number of path traces.

--- a/docs/resources/voice.md
+++ b/docs/resources/voice.md
@@ -48,7 +48,7 @@ resource "thousandeyes_voice" "example_voice_test" {
 - `dscp_id` (Number) The DSCP ID.
 - `duration` (Number) The duration of the test, in seconds (5 to 30).
 - `enabled` (Boolean) Enables or disables the test.
-- `groups` (Block Set) The array of label objects. (see [below for nested schema](#nestedblock--groups))
+- `groups` (Block Set, Deprecated) The array of label objects. (see [below for nested schema](#nestedblock--groups))
 - `jitter_buffer` (Number) The de-jitter buffer size, in seconds (0 to 150).
 - `mtu_measurements` (Boolean) Measure MTU sizes on the network from agents to the target.
 - `num_path_traces` (Number) The number of path traces.

--- a/docs/resources/web_transaction.md
+++ b/docs/resources/web_transaction.md
@@ -33,7 +33,7 @@ This resource allows users to create a transaction test. This test type is a scr
 - `description` (String) A description of the alert rule. Defaults to an empty string.
 - `desired_status_code` (String) The valid HTTP response code you’re interested in retrieving.
 - `enabled` (Boolean) Enables or disables the test.
-- `groups` (Block Set) The array of label objects. (see [below for nested schema](#nestedblock--groups))
+- `groups` (Block Set, Deprecated) The array of label objects. (see [below for nested schema](#nestedblock--groups))
 - `http_target_time` (Number) The target time for HTTP server completion, specified in milliseconds.
 - `http_time_limit` (Number) The target time for HTTP server limits, specified in seconds.
 - `http_version` (Number) Set to 2 for the default HTTP version (prefer HTTP/2), or 1 for HTTP/1.1 only.

--- a/thousandeyes/schemas.go
+++ b/thousandeyes/schemas.go
@@ -594,6 +594,7 @@ var schemas = map[string]*schema.Schema{
 		Type:        schema.TypeSet,
 		Description: "The array of label objects.",
 		Optional:    true,
+		Deprecated:  "This attribute will become a computed attribute. Use thousandeyes_label to link labels to tests",
 		Elem: &schema.Resource{
 			// Schema definition here is to support group objects returned from
 			// reads of test resources.


### PR DESCRIPTION
Before releasing the BREAKING CHANGE that fixes them.

Docs were updated with `go generate`. Users should see the deprecation warning when planning and applying terraform.
We should release this before the breaking change here: https://github.com/thousandeyes/terraform-provider-thousandeyes/pull/125