### PR TITLE
docs: Adds issue template for bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue-template.yml
+++ b/.github/ISSUE_TEMPLATE/issue-template.yml
@@ -41,26 +41,18 @@ body:
     validations:
       required: true
   - type: textarea
-    id: addcode
+    id: addcommentscode
     attributes:
-      label: Any additional code to reproduce the bug
-      description: Please provide any additional code to reproduce the bug. You may use markdown inside the textbox to format your code
-      placeholder: <code>
+      label: Any additional comments or code?
+      description: Use this space to write down any additional comments or code to reproduce the bug. You may use markdown inside the textbox to format your code
+      placeholder: Comment or <code>
     validations:
-      required: true
+      required: false
   - type: textarea
     id: reproduce
     attributes:
       label: Steps to reproduce the bug
       description: Please provide the steps to reproduce the issue
       placeholder: Step 1...
-    validations:
-      required: true
-  - type: textarea
-    id: addcomments
-    attributes:
-      label: Any additional comments?
-      description: Use this space to write down any additional comments
-      placeholder: Comment
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/issue-template.yml
+++ b/.github/ISSUE_TEMPLATE/issue-template.yml
@@ -1,0 +1,66 @@
+name: Bug Report
+description: File a bug report
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to fill out this bug report!
+  - type: textarea
+    id: versions
+    attributes:
+      label: What versions are you using?
+      description: Please share the provider and terraform versions, and any other version that is relevant to troubleshoot the issue
+      placeholder: Terraform version 1.5.2, Provider version 2.0.1
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+      description: Please provide a detailed description of what was expected to happen
+      placeholder: Plan should have produced X or Y
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: What actually happened?
+      description: Please provide a detailed description of what actually happened
+      placeholder: Provider produced inconsistent final plan
+    validations:
+      required: true
+  - type: textarea
+    id: code
+    attributes:
+      label: Terraform code to reproduce the bug
+      description: Please provide the minimum required amount of code to reproduce the bug. If the code is not sufficient to reproduce the issue, then we might discard the bug
+      placeholder: <code>
+      render: hcl
+    validations:
+      required: true
+  - type: textarea
+    id: addcode
+    attributes:
+      label: Any additional code to reproduce the bug
+      description: Please provide any additional code to reproduce the bug. You may use markdown inside the textbox to format your code
+      placeholder: <code>
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce the bug
+      description: Please provide the steps to reproduce the issue
+      placeholder: Step 1...
+    validations:
+      required: true
+  - type: textarea
+    id: addcomments
+    attributes:
+      label: Any additional comments?
+      description: Use this space to write down any additional comments
+      placeholder: Comment
+    validations:
+      required: true


### PR DESCRIPTION
The page will look like this (apologies for the screenshot cuts):
<img width="1521" alt="image" src="https://github.com/thousandeyes/terraform-provider-thousandeyes/assets/47182547/28804155-814e-47bd-b90c-b984634296ea">
<img width="1471" alt="image" src="https://github.com/thousandeyes/terraform-provider-thousandeyes/assets/47182547/91aefd87-0b95-46c5-b4b1-e738676544df">
<img width="1092" alt="image" src="https://github.com/thousandeyes/terraform-provider-thousandeyes/assets/47182547/e32d9e7d-1b02-4c83-9344-3138d771cdf3">

What do you think?