### PR TITLE
CAPS-15 Remove standalone `use_public_bgp = false` flag from agent-to-server example

### DIFF
--- a/docs/resources/agent_to_server.md
+++ b/docs/resources/agent_to_server.md
@@ -15,7 +15,6 @@ resource "thousandeyes_agent_to_server" "example_agent_to_server_test" {
   test_name      = "Example Agent to Server test set from Terraform provider"
   interval       = 120
   alerts_enabled = false
-  use_public_bgp = false
 
   server = "www.thousandeyes.com"
   port   = 443

--- a/examples/resources/thousandeyes_agent_to_server/resource.tf
+++ b/examples/resources/thousandeyes_agent_to_server/resource.tf
@@ -2,7 +2,6 @@ resource "thousandeyes_agent_to_server" "example_agent_to_server_test" {
   test_name      = "Example Agent to Server test set from Terraform provider"
   interval       = 120
   alerts_enabled = false
-  use_public_bgp = false
 
   server = "www.thousandeyes.com"
   port   = 443


### PR DESCRIPTION
This (incorrect) content leads customers to believe they can simply flip the value to `true` and have BGP measurements enabled, which is not the case - they need to use the `bgp_measurements` flag first and augment it with either `bgp_monitors` or `use_public_bgp`.