### PR TITLE
Fix problem with resources deleted outside Terraform.

### DIFF
--- a/thousandeyes/resource_agent_to_agent.go
+++ b/thousandeyes/resource_agent_to_agent.go
@@ -36,19 +36,9 @@ func resourceAgentToAgent() *schema.Resource {
 }
 
 func resourceAgentAgentRead(d *schema.ResourceData, m interface{}) error {
-	client := m.(*thousandeyes.Client)
-
-	log.Printf("[INFO] Reading Thousandeyes Test %s", d.Id())
-	id, _ := strconv.ParseInt(d.Id(), 10, 64)
-	remote, err := client.GetAgentAgent(id)
-	if err != nil {
-		return err
-	}
-	err = ResourceRead(d, remote)
-	if err != nil {
-		return err
-	}
-	return nil
+	return GetResource(d, m, func(client *thousandeyes.Client, id int64) (interface{}, error) {
+		return client.GetAgentAgent(id)
+	})
 }
 
 func resourceAgentAgentUpdate(d *schema.ResourceData, m interface{}) error {

--- a/thousandeyes/resource_agent_to_server.go
+++ b/thousandeyes/resource_agent_to_server.go
@@ -39,19 +39,9 @@ func resourceAgentToServer() *schema.Resource {
 }
 
 func resourceAgentServerRead(d *schema.ResourceData, m interface{}) error {
-	client := m.(*thousandeyes.Client)
-
-	log.Printf("[INFO] Reading Thousandeyes Test %s", d.Id())
-	id, _ := strconv.ParseInt(d.Id(), 10, 64)
-	remote, err := client.GetAgentServer(id)
-	if err != nil {
-		return err
-	}
-	err = ResourceRead(d, remote)
-	if err != nil {
-		return err
-	}
-	return nil
+	return GetResource(d, m, func(client *thousandeyes.Client, id int64) (interface{}, error) {
+		return client.GetAgentServer(id)
+	})
 }
 
 func resourceAgentServerUpdate(d *schema.ResourceData, m interface{}) error {

--- a/thousandeyes/resource_alert_rule.go
+++ b/thousandeyes/resource_alert_rule.go
@@ -25,19 +25,9 @@ func resourceAlertRule() *schema.Resource {
 }
 
 func resourceAlertRuleRead(d *schema.ResourceData, m interface{}) error {
-	client := m.(*thousandeyes.Client)
-
-	log.Printf("[INFO] Reading Thousandeyes Test %s", d.Id())
-	id, _ := strconv.ParseInt(d.Id(), 10, 64)
-	remote, err := client.GetAlertRule(id)
-	if err != nil {
-		return err
-	}
-	err = ResourceRead(d, remote)
-	if err != nil {
-		return err
-	}
-	return nil
+	return GetResource(d, m, func(client *thousandeyes.Client, id int64) (interface{}, error) {
+		return client.GetAlertRule(id)
+	})
 }
 
 func resourceAlertRuleUpdate(d *schema.ResourceData, m interface{}) error {

--- a/thousandeyes/resource_bgp.go
+++ b/thousandeyes/resource_bgp.go
@@ -24,19 +24,9 @@ func resourceBGP() *schema.Resource {
 }
 
 func resourceBGPRead(d *schema.ResourceData, m interface{}) error {
-	client := m.(*thousandeyes.Client)
-
-	log.Printf("[INFO] Reading Thousandeyes Test %s", d.Id())
-	id, _ := strconv.ParseInt(d.Id(), 10, 64)
-	remote, err := client.GetBGP(id)
-	if err != nil {
-		return err
-	}
-	err = ResourceRead(d, remote)
-	if err != nil {
-		return err
-	}
-	return nil
+	return GetResource(d, m, func(client *thousandeyes.Client, id int64) (interface{}, error) {
+		return client.GetBGP(id)
+	})
 }
 
 func resourceBGPUpdate(d *schema.ResourceData, m interface{}) error {

--- a/thousandeyes/resource_dns_server.go
+++ b/thousandeyes/resource_dns_server.go
@@ -24,19 +24,9 @@ func resourceDNSServer() *schema.Resource {
 }
 
 func resourceDNSServerRead(d *schema.ResourceData, m interface{}) error {
-	client := m.(*thousandeyes.Client)
-
-	log.Printf("[INFO] Reading Thousandeyes Test %s", d.Id())
-	id, _ := strconv.ParseInt(d.Id(), 10, 64)
-	remote, err := client.GetDNSServer(id)
-	if err != nil {
-		return err
-	}
-	err = ResourceRead(d, remote)
-	if err != nil {
-		return err
-	}
-	return nil
+	return GetResource(d, m, func(client *thousandeyes.Client, id int64) (interface{}, error) {
+		return client.GetDNSServer(id)
+	})
 }
 
 func resourceDNSServerUpdate(d *schema.ResourceData, m interface{}) error {

--- a/thousandeyes/resource_dns_trace.go
+++ b/thousandeyes/resource_dns_trace.go
@@ -24,19 +24,9 @@ func resourceDNSTrace() *schema.Resource {
 }
 
 func resourceDNSTraceRead(d *schema.ResourceData, m interface{}) error {
-	client := m.(*thousandeyes.Client)
-
-	log.Printf("[INFO] Reading Thousandeyes Test %s", d.Id())
-	id, _ := strconv.ParseInt(d.Id(), 10, 64)
-	remote, err := client.GetDNSTrace(id)
-	if err != nil {
-		return err
-	}
-	err = ResourceRead(d, remote)
-	if err != nil {
-		return err
-	}
-	return nil
+	return GetResource(d, m, func(client *thousandeyes.Client, id int64) (interface{}, error) {
+		return client.GetDNSTrace(id)
+	})
 }
 
 func resourceDNSTraceUpdate(d *schema.ResourceData, m interface{}) error {

--- a/thousandeyes/resource_dnssec.go
+++ b/thousandeyes/resource_dnssec.go
@@ -1,10 +1,8 @@
 package thousandeyes
 
 import (
-	"fmt"
 	"log"
 	"strconv"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/thousandeyes/thousandeyes-sdk-go/v2"
@@ -26,21 +24,9 @@ func resourceDNSSec() *schema.Resource {
 }
 
 func resourceDNSSecRead(d *schema.ResourceData, m interface{}) error {
-	log.Printf("[INFO] d object: \n\n%s", strings.Replace(
-		fmt.Sprintf("%#v", d), ", ", "\n", -1))
-	client := m.(*thousandeyes.Client)
-
-	log.Printf("[INFO] Reading Thousandeyes Test %s", d.Id())
-	id, _ := strconv.ParseInt(d.Id(), 10, 64)
-	remote, err := client.GetDNSSec(id)
-	if err != nil {
-		return err
-	}
-	err = ResourceRead(d, remote)
-	if err != nil {
-		return err
-	}
-	return nil
+	return GetResource(d, m, func(client *thousandeyes.Client, id int64) (interface{}, error) {
+		return client.GetDNSSec(id)
+	})
 }
 
 func resourceDNSSecUpdate(d *schema.ResourceData, m interface{}) error {

--- a/thousandeyes/resource_ftp_server.go
+++ b/thousandeyes/resource_ftp_server.go
@@ -26,19 +26,9 @@ func resourceFTPServer() *schema.Resource {
 }
 
 func resourceFTPServerRead(d *schema.ResourceData, m interface{}) error {
-	client := m.(*thousandeyes.Client)
-
-	log.Printf("[INFO] Reading Thousandeyes Test %s", d.Id())
-	id, _ := strconv.ParseInt(d.Id(), 10, 64)
-	remote, err := client.GetFTPServer(id)
-	if err != nil {
-		return err
-	}
-	err = ResourceRead(d, remote)
-	if err != nil {
-		return err
-	}
-	return nil
+	return GetResource(d, m, func(client *thousandeyes.Client, id int64) (interface{}, error) {
+		return client.GetFTPServer(id)
+	})
 }
 
 func resourceFTPServerUpdate(d *schema.ResourceData, m interface{}) error {

--- a/thousandeyes/resource_http_server.go
+++ b/thousandeyes/resource_http_server.go
@@ -24,19 +24,9 @@ func resourceHTTPServer() *schema.Resource {
 }
 
 func resourceHTTPServerRead(d *schema.ResourceData, m interface{}) error {
-	client := m.(*thousandeyes.Client)
-
-	log.Printf("[INFO] Reading Thousandeyes Test %s", d.Id())
-	id, _ := strconv.ParseInt(d.Id(), 10, 64)
-	remote, err := client.GetHTTPServer(id)
-	if err != nil {
-		return err
-	}
-	err = ResourceRead(d, remote)
-	if err != nil {
-		return err
-	}
-	return nil
+	return GetResource(d, m, func(client *thousandeyes.Client, id int64) (interface{}, error) {
+		return client.GetHTTPServer(id)
+	})
 }
 
 func resourceHTTPServerUpdate(d *schema.ResourceData, m interface{}) error {

--- a/thousandeyes/resource_label.go
+++ b/thousandeyes/resource_label.go
@@ -46,9 +46,15 @@ func resourceGroupLabelRead(d *schema.ResourceData, m interface{}) error {
 	log.Printf("[INFO] Reading Thousandeyes Label %s", d.Id())
 	id, _ := strconv.ParseInt(d.Id(), 10, 64)
 	remote, err := client.GetGroupLabel(id)
-	if err != nil {
+
+	if err != nil && IsNotFoundError(err) {
+		log.Printf("[INFO] Resource was deleted - will recreate it")
+		d.SetId("") // Set ID to empty to mark the resource as non-existent
+		return nil
+	} else if err != nil {
 		return err
 	}
+	
 	// In order to prevent schema conficts for test responses,  we retain
 	// the stored state for tests attached to a group to just a test ID.
 	testIDs := []thousandeyes.GenericTest{}

--- a/thousandeyes/resource_page_load.go
+++ b/thousandeyes/resource_page_load.go
@@ -24,19 +24,9 @@ func resourcePageLoad() *schema.Resource {
 }
 
 func resourcePageLoadRead(d *schema.ResourceData, m interface{}) error {
-	client := m.(*thousandeyes.Client)
-
-	log.Printf("[INFO] Reading Thousandeyes Test %s", d.Id())
-	id, _ := strconv.ParseInt(d.Id(), 10, 64)
-	remote, err := client.GetPageLoad(id)
-	if err != nil {
-		return err
-	}
-	err = ResourceRead(d, remote)
-	if err != nil {
-		return err
-	}
-	return nil
+	return GetResource(d, m, func(client *thousandeyes.Client, id int64) (interface{}, error) {
+		return client.GetPageLoad(id)
+	})
 }
 
 func resourcePageLoadUpdate(d *schema.ResourceData, m interface{}) error {

--- a/thousandeyes/resource_sip_server.go
+++ b/thousandeyes/resource_sip_server.go
@@ -24,19 +24,9 @@ func resourceSIPServer() *schema.Resource {
 }
 
 func resourceSIPServerRead(d *schema.ResourceData, m interface{}) error {
-	client := m.(*thousandeyes.Client)
-
-	log.Printf("[INFO] Reading Thousandeyes Test %s", d.Id())
-	id, _ := strconv.ParseInt(d.Id(), 10, 64)
-	remote, err := client.GetSIPServer(id)
-	if err != nil {
-		return err
-	}
-	err = ResourceRead(d, remote)
-	if err != nil {
-		return err
-	}
-	return nil
+	return GetResource(d, m, func(client *thousandeyes.Client, id int64) (interface{}, error) {
+		return client.GetSIPServer(id)
+	})
 }
 
 func resourceSIPServerUpdate(d *schema.ResourceData, m interface{}) error {

--- a/thousandeyes/resource_voice.go
+++ b/thousandeyes/resource_voice.go
@@ -24,19 +24,9 @@ func resourceRTPStream() *schema.Resource {
 }
 
 func resourceRTPStreamRead(d *schema.ResourceData, m interface{}) error {
-	client := m.(*thousandeyes.Client)
-
-	log.Printf("[INFO] Reading Thousandeyes Test %s", d.Id())
-	id, _ := strconv.ParseInt(d.Id(), 10, 64)
-	remote, err := client.GetRTPStream(id)
-	if err != nil {
-		return err
-	}
-	err = ResourceRead(d, remote)
-	if err != nil {
-		return err
-	}
-	return nil
+	return GetResource(d, m, func(client *thousandeyes.Client, id int64) (interface{}, error) {
+		return client.GetRTPStream(id)
+	})
 }
 
 func resourceRTPStreamUpdate(d *schema.ResourceData, m interface{}) error {

--- a/thousandeyes/resource_web_transactions.go
+++ b/thousandeyes/resource_web_transactions.go
@@ -24,19 +24,9 @@ func resourceWebTransaction() *schema.Resource {
 }
 
 func resourceWebTransactionRead(d *schema.ResourceData, m interface{}) error {
-	client := m.(*thousandeyes.Client)
-
-	log.Printf("[INFO] Reading Thousandeyes Test %s", d.Id())
-	id, _ := strconv.ParseInt(d.Id(), 10, 64)
-	remote, err := client.GetWebTransaction(id)
-	if err != nil {
-		return err
-	}
-	err = ResourceRead(d, remote)
-	if err != nil {
-		return err
-	}
-	return nil
+	return GetResource(d, m, func(client *thousandeyes.Client, id int64) (interface{}, error) {
+		return client.GetWebTransaction(id)
+	})
 }
 
 func resourceWebTransactionUpdate(d *schema.ResourceData, m interface{}) error {

--- a/thousandeyes/util.go
+++ b/thousandeyes/util.go
@@ -2,6 +2,7 @@ package thousandeyes
 
 import (
 	"errors"
+	"log"
 	"reflect"
 	"strconv"
 	"strings"
@@ -10,6 +11,18 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/thousandeyes/thousandeyes-sdk-go/v2"
 )
+
+type ResourceReadFunc func(client *thousandeyes.Client, id int64) (interface{}, error)
+
+func IsNotFoundError(err error) bool {
+    notFoundPatterns := []string{"404", "Not Found"}
+    for _, pattern := range notFoundPatterns {
+        if strings.Contains(err.Error(), pattern) {
+            return true
+        }
+    }
+    return false
+}
 
 func expandAgents(v interface{}) thousandeyes.Agents {
 	var agents thousandeyes.Agents
@@ -120,6 +133,36 @@ func ResourceBuildStruct(d *schema.ResourceData, structPtr interface{}) interfac
 		}
 	}
 	return resourceFixups(d, structPtr)
+}
+
+// resourceRead is a generic function for reading resources.
+func GetResource(d *schema.ResourceData, m interface{}, readFunc ResourceReadFunc) error {
+	client := m.(*thousandeyes.Client)
+
+	log.Printf("[INFO] Reading Thousandeyes Test %s", d.Id())
+	id, err := strconv.ParseInt(d.Id(), 10, 64)
+	if err != nil {
+		return err
+	}
+
+	remote, err := readFunc(client, id)
+
+	// Check if the resource no longer exists
+	if err != nil && IsNotFoundError(err) {
+		log.Printf("[INFO] Resource was deleted - will recreate it")
+		d.SetId("") // Set ID to empty to mark the resource as non-existent
+		return nil
+	} else if err != nil {
+		return err
+	}
+
+	// Continue with updating the state
+	err = ResourceRead(d, remote)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // ResourceRead sets values for a schema.ResourceData object by names derived


### PR DESCRIPTION
Fixes #112.

Problem was that when attempting to read the resource, we were not handling the 404 properly. Now, we set the ID to null so that terraform understands that the resource no longer exists and tries to recreate it.

Tested locally and now, after the resource is deleted manually in the UI, a `terraform plan` attempts to re-create it.