### PR TITLE
feat: added ip addresses to agent data source

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,5 +90,9 @@ Follow the instructions to [install it as a plugin](https://developer.hashicorp.
 ## Maintainers
 This provider plugin is maintained by the ThousandEyes engineering team and accepts community contributions.
 
+> [!NOTE]  
+> The `docs/` folder should not be changed manually. Instead, if there are changes to the examples, inputs/outputs of any `data_source` or `resource`, you need to run `go generate` locally and commit the resulting changes to the `.md` files. 
+
+
 ## Acknowledgements
 ThousandEyes would like to thank William Fleming, John Dyer, and Joshua Blanchard for their contribution and community maintenance of this project.

--- a/docs/data-sources/account_group.md
+++ b/docs/data-sources/account_group.md
@@ -27,7 +27,7 @@ resource "thousandeyes_http_server" "thousandeyes_http_test" {
   }
 
   agents {
-    agent_id = 3 # Singapure
+    agent_id = 3 # Singapur
   }
 }
 ```

--- a/docs/data-sources/account_group.md
+++ b/docs/data-sources/account_group.md
@@ -27,7 +27,7 @@ resource "thousandeyes_http_server" "thousandeyes_http_test" {
   }
 
   agents {
-    agent_id = 3 # Singapur
+    agent_id = 3 # Singapure
   }
 }
 ```

--- a/docs/data-sources/account_group.md
+++ b/docs/data-sources/account_group.md
@@ -27,7 +27,7 @@ resource "thousandeyes_http_server" "thousandeyes_http_test" {
   }
 
   agents {
-    agent_id = 3 # Singapure
+    agent_id = 3 # Singapore
   }
 }
 ```

--- a/docs/data-sources/agent.md
+++ b/docs/data-sources/agent.md
@@ -39,5 +39,6 @@ resource "thousandeyes_http_server" "www_thousandeyes_http_test" {
 
 - `agent_id` (Number) The unique ID of the agent.
 - `id` (String) The ID of this resource.
+- `ip_addresses` (List of String) The array of IP Addresses entries for the agent.
 
 

--- a/examples/data-sources/thousandeyes_account_group/data-source.tf
+++ b/examples/data-sources/thousandeyes_account_group/data-source.tf
@@ -14,6 +14,6 @@ resource "thousandeyes_http_server" "thousandeyes_http_test" {
   }
 
   agents {
-    agent_id = 3 # Singapure
+    agent_id = 3 # Singapore
   }
 }

--- a/examples/data-sources/thousandeyes_account_group/data-source.tf
+++ b/examples/data-sources/thousandeyes_account_group/data-source.tf
@@ -14,6 +14,6 @@ resource "thousandeyes_http_server" "thousandeyes_http_test" {
   }
 
   agents {
-    agent_id = 3 # Singapur
+    agent_id = 3 # Singapure
   }
 }

--- a/thousandeyes/data_source_thousandeyes_agent.go
+++ b/thousandeyes/data_source_thousandeyes_agent.go
@@ -23,6 +23,12 @@ func dataSourceThousandeyesAgent() *schema.Resource {
 				Computed:    true,
 				Description: "The unique ID of the agent.",
 			},
+			"ip_addresses": {
+				Type:        schema.TypeList,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Computed:    true,
+				Description: "The array of IP Addresses entries for the agent.",
+			},
 		},
 		Description: "This data source allows you to define a ThousandEyes agent. For more information, see [Global Vantage Points](https://docs.thousandeyes.com/product-documentation/global-vantage-points).",
 	}
@@ -60,6 +66,10 @@ func dataSourceThousandeyesAgentRead(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 	err = d.Set("agent_id", found.AgentID)
+	if err != nil {
+		return err
+	}
+	err = d.Set("ip_addresses", found.IPAddresses)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
As requested within #128 by several users this adds ip addresses to the Agent DataSource:

```
Changes to Outputs:
  + agent_id     = 123213
  + agent_name   = "Vancouver, Canada"
  + ip_addresses = [
      + "155.313.108.19",
      + "155.313.108.23",
      + "155.313.108.15",
      + "2607:f6f3:3400:96::2:7",
      + "2607:f6f3:3400:96::2:4",
    ]
╷
```