### PR TITLE
fix: default alert rule not being read

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,3 +25,13 @@ jobs:
         run: |
           git diff --compact-summary --exit-code || \
           (echo; echo "Unexpected difference in directories after code generation. Run 'go generate' command and commit."; exit 1)
+
+  unit:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: 'go.mod'
+      - run: go test -v -cover ./...

--- a/thousandeyes/util.go
+++ b/thousandeyes/util.go
@@ -213,21 +213,17 @@ func FixReadValues(m interface{}, name string) (interface{}, error) {
 		}
 
 	// Remove all alert rule fields except for rule ID. Ignore default rules.
+	// Remove all alert rule fields except for rule ID.
 	case "alert_rules":
 		alert_rules := m.([]interface{})
 		// Edit the alert_rules slice in place, to return the same type.
 		i := 0
 		for i < len(alert_rules) {
 			rule := alert_rules[i].(map[string]interface{})
-			if is_default, ok := rule["default"]; ok && is_default != nil && *is_default.(*bool) {
-				// Remove this item from the slice
-				alert_rules = append(alert_rules[:i], alert_rules[i+1:]...)
-			} else {
-				alert_rules[i] = map[string]interface{}{
-					"rule_id": rule["rule_id"],
-				}
-				i = i + 1
+			alert_rules[i] = map[string]interface{}{
+				"rule_id": rule["rule_id"],
 			}
+			i = i + 1
 		}
 		m = alert_rules
 

--- a/thousandeyes/util.go
+++ b/thousandeyes/util.go
@@ -15,13 +15,13 @@ import (
 type ResourceReadFunc func(client *thousandeyes.Client, id int64) (interface{}, error)
 
 func IsNotFoundError(err error) bool {
-    notFoundPatterns := []string{"404", "not found"}
-    for _, pattern := range notFoundPatterns {
-        if strings.Contains(strings.ToLower(err.Error()), pattern) {
-            return true
-        }
-    }
-    return false
+	notFoundPatterns := []string{"404", "not found"}
+	for _, pattern := range notFoundPatterns {
+		if strings.Contains(strings.ToLower(err.Error()), pattern) {
+			return true
+		}
+	}
+	return false
 }
 
 func expandAgents(v interface{}) thousandeyes.Agents {
@@ -53,68 +53,6 @@ func expandAlertRules(alertRules *[]thousandeyes.AlertRule) *[]thousandeyes.Aler
 	return ret
 }
 
-func expandBGPMonitors(v interface{}) thousandeyes.BGPMonitors {
-	var bgpMonitors thousandeyes.BGPMonitors
-
-	for _, er := range v.([]interface{}) {
-		rer := er.(map[string]interface{})
-		bgpMonitor := &thousandeyes.BGPMonitor{
-			MonitorID: thousandeyes.Int64(rer["monitor_id"].(int64)),
-		}
-		bgpMonitors = append(bgpMonitors, *bgpMonitor)
-	}
-
-	return bgpMonitors
-}
-
-func expandDNSServers(v interface{}) []thousandeyes.Server {
-	var dnsServers []thousandeyes.Server
-
-	for _, er := range v.([]interface{}) {
-		rer := er.(map[string]interface{})
-		targetDNSServer := &thousandeyes.Server{
-			ServerName: thousandeyes.String(rer["server_name"].(string)),
-		}
-		dnsServers = append(dnsServers, *targetDNSServer)
-	}
-
-	return dnsServers
-}
-
-func unpackSIPAuthData(i interface{}) thousandeyes.SIPAuthData {
-	var m = i.(map[string]interface{})
-	var sipAuthData = thousandeyes.SIPAuthData{}
-
-	for k, v := range m {
-		if k == "auth_user" {
-			sipAuthData.AuthUser = thousandeyes.String(v.(string))
-		}
-		if k == "password" {
-			sipAuthData.Password = thousandeyes.String(v.(string))
-		}
-		if k == "port" {
-			port, err := strconv.Atoi(v.(string))
-			if err == nil {
-				sipAuthData.Port = thousandeyes.Int(port)
-			}
-		}
-		if k == "protocol" {
-			sipAuthData.Protocol = thousandeyes.String(v.(string))
-		}
-		if k == "sip_proxy" {
-			sipAuthData.SIPProxy = thousandeyes.String(v.(string))
-		}
-		if k == "sip_registrar" {
-			sipAuthData.SIPRegistrar = thousandeyes.String(v.(string))
-		}
-		if k == "user" {
-			sipAuthData.User = thousandeyes.String(v.(string))
-		}
-	}
-
-	return sipAuthData
-}
-
 // ResourceBuildStruct fills the struct at a given address by querying a
 // schema.ResourceData object for the matching field.  It discovers the
 // matching value name by getting the JSON key from the struct field,
@@ -135,7 +73,7 @@ func ResourceBuildStruct(d *schema.ResourceData, structPtr interface{}) interfac
 	return resourceFixups(d, structPtr)
 }
 
-// resourceRead is a generic function for reading resources.
+// GetResource is a generic function for reading resources.
 func GetResource(d *schema.ResourceData, m interface{}, readFunc ResourceReadFunc) error {
 	client := m.(*thousandeyes.Client)
 
@@ -215,17 +153,12 @@ func FixReadValues(m interface{}, name string) (interface{}, error) {
 	// Remove all alert rule fields except for rule ID. Ignore default rules.
 	// Remove all alert rule fields except for rule ID.
 	case "alert_rules":
-		alert_rules := m.([]interface{})
-		// Edit the alert_rules slice in place, to return the same type.
-		i := 0
-		for i < len(alert_rules) {
-			rule := alert_rules[i].(map[string]interface{})
-			alert_rules[i] = map[string]interface{}{
+		for i, v := range m.([]interface{}) {
+			rule := v.(map[string]interface{})
+			m.([]interface{})[i] = map[string]interface{}{
 				"rule_id": rule["rule_id"],
 			}
-			i = i + 1
 		}
-		m = alert_rules
 
 	// Remove all public BGP monitors. (ThousandEyes does not allow
 	// specifying individual public BGP monitors, and all available

--- a/thousandeyes/util_test.go
+++ b/thousandeyes/util_test.go
@@ -182,6 +182,9 @@ func TestFixReadValues(t *testing.T) {
 		map[string]interface{}{
 			"rule_id": thousandeyes.Int(2),
 		},
+		map[string]interface{}{
+			"rule_id": thousandeyes.Int(3),
+		},
 	}
 	output, err = FixReadValues(alertRulesInput, "alert_rules")
 	if err != nil {
@@ -317,11 +320,19 @@ func TestFixReadValues(t *testing.T) {
 			"test_id":   "2",
 		},
 	}
+	testsTarget := []interface{}{
+		map[string]interface{}{
+			"test_id": "1",
+		},
+		map[string]interface{}{
+			"test_id": "2",
+		},
+	}
 	output, err = FixReadValues(testsInput, "tests")
 	if err != nil {
 		t.Errorf("tests input returned error: %s", err.Error())
 	}
-	if output != nil {
+	if reflect.DeepEqual(output, testsTarget) != true {
 		t.Errorf("Values not stripped correctly from tests input: Received %#v Expected %#v", output, nil)
 	}
 


### PR DESCRIPTION
This fixes #111 .

It seems to conflict with the fix that was done [here](https://github.com/thousandeyes/terraform-provider-thousandeyes/pull/75) for #73. However, was trying out the scenarios from #73  locally:

- Create test with `alerts_enabled` set to `true` and without specifying any alert rule
- Create test with `alerts_enabled` set to `false` and with 2 alert rules, one of them being a default alert rule
- Remove one of the alert rules from a test which had 2 alert rules

and both Terraform plan/apply, as well as subsequent terraform plans, ran ok (and the subsequent terraform plans showed no changes). 

@raul-te not sure if you have any objection or know anything else that I should further test before merging this. Because it  does seems that filtering out the Default Alert Rules is no longer needed... 

NOTE: We do need some tests for this repo though, as we should have more visibility when fixing something do make sure that we don't introduce any regression.
