### PR TITLE
feat: adding support for webhook notifications

### DIFF
--- a/docs/resources/alert_rule.md
+++ b/docs/resources/alert_rule.md
@@ -59,6 +59,7 @@ Optional:
 
 - `email` (Block Set) The email notification. (see [below for nested schema](#nestedblock--notifications--email))
 - `third_party` (Block Set) Third party notification. (see [below for nested schema](#nestedblock--notifications--third_party))
+- `webhook` (Block Set) Webhook notification. (see [below for nested schema](#nestedblock--notifications--webhook))
 
 <a id="nestedblock--notifications--email"></a>
 ### Nested Schema for `notifications.email`
@@ -77,4 +78,10 @@ Required:
 - `integration_id` (String) The integration ID, as a string.
 - `integration_type` (String) The integration type, as a string.
 
+<a id="nestedblock--notifications--webhook"></a>
+### Nested Schema for `notifications.webhook`
 
+Required:
+
+- `integration_id` (String) The integration ID, as a string.
+- `integration_type` (String) The integration type, as a string.

--- a/docs/resources/alert_rule.md
+++ b/docs/resources/alert_rule.md
@@ -59,7 +59,6 @@ Optional:
 
 - `email` (Block Set) The email notification. (see [below for nested schema](#nestedblock--notifications--email))
 - `third_party` (Block Set) Third party notification. (see [below for nested schema](#nestedblock--notifications--third_party))
-- `webhook` (Block Set) Webhook notification. (see [below for nested schema](#nestedblock--notifications--webhook))
 
 <a id="nestedblock--notifications--email"></a>
 ### Nested Schema for `notifications.email`
@@ -72,14 +71,6 @@ Optional:
 
 <a id="nestedblock--notifications--third_party"></a>
 ### Nested Schema for `notifications.third_party`
-
-Required:
-
-- `integration_id` (String) The integration ID, as a string.
-- `integration_type` (String) The integration type, as a string.
-
-<a id="nestedblock--notifications--webhook"></a>
-### Nested Schema for `notifications.webhook`
 
 Required:
 

--- a/docs/resources/alert_rule.md
+++ b/docs/resources/alert_rule.md
@@ -59,6 +59,7 @@ Optional:
 
 - `email` (Block Set) The email notification. (see [below for nested schema](#nestedblock--notifications--email))
 - `third_party` (Block Set) Third party notification. (see [below for nested schema](#nestedblock--notifications--third_party))
+- `webhook` (Block Set) Webhook notification. (see [below for nested schema](#nestedblock--notifications--webhook))
 
 <a id="nestedblock--notifications--email"></a>
 ### Nested Schema for `notifications.email`
@@ -76,3 +77,14 @@ Required:
 
 - `integration_id` (String) The integration ID, as a string.
 - `integration_type` (String) The integration type, as a string.
+
+
+<a id="nestedblock--notifications--webhook"></a>
+### Nested Schema for `notifications.webhook`
+
+Required:
+
+- `integration_id` (String) The integration ID, as a string.
+- `integration_type` (String) The integration type, as a string.
+
+

--- a/thousandeyes/schemas.go
+++ b/thousandeyes/schemas.go
@@ -614,6 +614,25 @@ var schemas = map[string]*schema.Schema{
 						},
 					},
 				},
+				"webhook": {
+					Type:        schema.TypeSet,
+					Description: "Webhook notification.",
+					Optional:    true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"integration_id": {
+								Type:        schema.TypeString,
+								Description: "The integration ID, as a string.",
+								Required:    true,
+							},
+							"integration_type": {
+								Type:        schema.TypeString,
+								Description: "The integration type, as a string.",
+								Required:    true,
+							},
+						},
+					},
+				},
 			},
 		},
 	},

--- a/thousandeyes/util_test.go
+++ b/thousandeyes/util_test.go
@@ -370,6 +370,30 @@ func TestFixReadValues(t *testing.T) {
 	if reflect.DeepEqual(output, thirdPartyNotificationsTarget) != true {
 		t.Errorf("Values not stripped correctly from third party notifications input: Received %#v Expected %#v", output, thirdPartyNotificationsTarget)
 	}
+
+	// webhook notifications
+	webhookNotificationsInput := []interface{}{
+		map[string]interface{}{
+			"integration_id":   "wb-0000",
+			"integration_type": "WEBHOOK",
+			"integration_name": "TEAMS CHANNEL",
+			"target":           "https://webhook.office.com",
+		},
+	}
+	webhookNotificationsTarget := []interface{}{
+		map[string]interface{}{
+			"integration_id":   "wb-0000",
+			"integration_type": "WEBHOOK",
+		},
+	}
+	
+	output, err = FixReadValues(webhookNotificationsInput, "webhook")
+	if err != nil {
+		t.Errorf("webhook notifications input returned error: %s", err.Error())
+	}
+	if reflect.DeepEqual(output, webhookNotificationsTarget) != true {
+		t.Errorf("Values not stripped correctly from webhook notifications input: Received %#v Expected %#v", output, webhookNotificationsTarget)
+	}
 }
 
 func TestResourceUpdate(t *testing.T) {


### PR DESCRIPTION
This will enable the use of webhook notifications within alerts using the recent SDK release.

Currently, you will receive an error if you set up alert rule notifications that use a custom webhook integration (for example, a Microsoft Teams integration data source) within Terraform.

Any feedback would be appreciated, thank you!

@joaomper-TE @shahid-te @pedro-te @phpinhei-te 