### PR TITLE
Replaced an obsolete param from goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v3.0.0
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
>--rm-dist¶
>since 2023-01-17 (v1.15.0), removed 2024-05-26 (v2.0)
>--rm-dist has been deprecated in favor of --clean.

https://goreleaser.com/deprecations/#-rm-dist