### PR TITLE
fix: reverts bgp fields defaults values and fixes unintended upgrade between v3 versions

### DIFF
--- a/thousandeyes/schemas/common_schema.go
+++ b/thousandeyes/schemas/common_schema.go
@@ -172,7 +172,6 @@ var CommonSchema = map[string]*schema.Schema{
 		Type:        schema.TypeBool,
 		Description: "Enable to automatically add all available Public BGP Monitors to the test.",
 		Optional:    true,
-		Default:     true,
 	},
 	// monitors (ex. bgp_monitors)
 	"monitors": {
@@ -258,7 +257,6 @@ var CommonSchema = map[string]*schema.Schema{
 		Description: "Enable BGP measurements. Set to true for enabled, false for disabled.",
 		Optional:    true,
 		Required:    false,
-		Default:     true,
 	},
 
 	// AGENT TO AGENT

--- a/thousandeyes/schemas/legacy_schema.go
+++ b/thousandeyes/schemas/legacy_schema.go
@@ -3,6 +3,7 @@ package schemas
 import (
 	"context"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"strings"
 )
 
 func LegacyTestSchema() *schema.Resource {
@@ -77,50 +78,54 @@ func LegacyTestSchema() *schema.Resource {
 }
 
 func LegacyTestStateUpgrade(ctx context.Context, rawState map[string]any, meta any) (map[string]any, error) {
+	if link, ok := rawState["link"].(string); ok && !strings.Contains(link, "/v7") {
 
-	for i, v := range rawState["agents"].([]interface{}) {
-		agent := v.(map[string]interface{})
-		rawState["agents"].([]interface{})[i] = agent["agent_id"]
-	}
-
-	if _, ok := rawState["alert_rules"].([]interface{}); ok {
-		for i, v := range rawState["alert_rules"].([]interface{}) {
-			alertRule := v.(map[string]interface{})
-			rawState["alert_rules"].([]interface{})[i] = alertRule["rule_id"]
+		if agents, ok := rawState["agents"].([]interface{}); ok {
+			for i, v := range rawState["agents"].([]interface{}) {
+				agent := v.(map[string]interface{})
+				agents[i] = agent["agent_id"]
+			}
 		}
-	}
 
-	if bgpMonitors, ok := rawState["bgp_monitors"].([]interface{}); ok {
-		for i, v := range rawState["bgp_monitors"].([]interface{}) {
-			monitor := v.(map[string]interface{})
-			bgpMonitors[i] = monitor["monitor_id"]
+		if _, ok := rawState["alert_rules"].([]interface{}); ok {
+			for i, v := range rawState["alert_rules"].([]interface{}) {
+				alertRule := v.(map[string]interface{})
+				rawState["alert_rules"].([]interface{})[i] = alertRule["rule_id"]
+			}
 		}
-		rawState["monitors"] = bgpMonitors
-		rawState["bgp_monitors"] = nil
-	}
 
-	// Only to maintain the backward compatibility
-	if groups, ok := rawState["groups"].([]interface{}); ok {
-		rawState["labels"] = make([]interface{}, len(groups))
-		for i, v := range rawState["groups"].([]interface{}) {
-			group := v.(map[string]interface{})
-			groups[i] = group["group_id"]
+		if bgpMonitors, ok := rawState["bgp_monitors"].([]interface{}); ok {
+			for i, v := range rawState["bgp_monitors"].([]interface{}) {
+				monitor := v.(map[string]interface{})
+				bgpMonitors[i] = monitor["monitor_id"]
+			}
+			rawState["monitors"] = bgpMonitors
+			rawState["bgp_monitors"] = nil
 		}
-		rawState["labels"] = groups
-		rawState["groups"] = nil
-	}
 
-	if sharedWithAccounts, ok := rawState["shared_with_accounts"].([]interface{}); ok {
-		for i, v := range rawState["shared_with_accounts"].([]interface{}) {
-			account := v.(map[string]interface{})
-			sharedWithAccounts[i] = account["aid"]
+		// Only to maintain the backward compatibility
+		if groups, ok := rawState["groups"].([]interface{}); ok {
+			rawState["labels"] = make([]interface{}, len(groups))
+			for i, v := range rawState["groups"].([]interface{}) {
+				group := v.(map[string]interface{})
+				groups[i] = group["group_id"]
+			}
+			rawState["labels"] = groups
+			rawState["groups"] = nil
 		}
-	}
 
-	if dnsSevers, ok := rawState["dns_servers"].([]interface{}); ok {
-		for i, v := range rawState["dns_servers"].([]interface{}) {
-			dnsServer := v.(map[string]interface{})
-			dnsSevers[i] = dnsServer["server_name"]
+		if sharedWithAccounts, ok := rawState["shared_with_accounts"].([]interface{}); ok {
+			for i, v := range rawState["shared_with_accounts"].([]interface{}) {
+				account := v.(map[string]interface{})
+				sharedWithAccounts[i] = account["aid"]
+			}
+		}
+
+		if dnsSevers, ok := rawState["dns_servers"].([]interface{}); ok {
+			for i, v := range rawState["dns_servers"].([]interface{}) {
+				dnsServer := v.(map[string]interface{})
+				dnsSevers[i] = dnsServer["server_name"]
+			}
 		}
 	}
 


### PR DESCRIPTION
- The API default values are not quite as the docs says, so we will rely on the response instead of defining defaults on the TF schema,
- We've added schema version on `v3.0.2`, so state upgrade was executed for any previous versions, including `v3.0.0|1`, which failed since the schema is already the new one.