### PR TITLE
fix: agent_to_server test icmp protocol

### DIFF
--- a/thousandeyes/acceptance_resources/agent_to_server/icmp_from_tcp.tf
+++ b/thousandeyes/acceptance_resources/agent_to_server/icmp_from_tcp.tf
@@ -1,0 +1,14 @@
+data "thousandeyes_agent" "amsterdam" {
+  agent_name = "Amsterdam, Netherlands"
+}
+
+resource "thousandeyes_agent_to_server" "test" {
+  test_name      = "UAT - Agent To Server ICMP"
+  interval       = 120
+  alerts_enabled = false
+  server         = "api.stg.thousandeyes.com"
+  protocol       = "icmp"
+  # port is not specified for ICMP
+  agents         = [data.thousandeyes_agent.amsterdam.agent_id]
+}
+

--- a/thousandeyes/acceptance_resources/agent_to_server/tcp_to_icmp.tf
+++ b/thousandeyes/acceptance_resources/agent_to_server/tcp_to_icmp.tf
@@ -1,0 +1,14 @@
+data "thousandeyes_agent" "amsterdam" {
+  agent_name = "Amsterdam, Netherlands"
+}
+
+resource "thousandeyes_agent_to_server" "test" {
+  test_name      = "UAT - Agent To Server TCP"
+  interval       = 120
+  alerts_enabled = false
+  server         = "api.stg.thousandeyes.com"
+  protocol       = "tcp"
+  port           = 443
+  agents         = [data.thousandeyes_agent.amsterdam.agent_id]
+}
+

--- a/thousandeyes/resource_agent_to_server.go
+++ b/thousandeyes/resource_agent_to_server.go
@@ -22,7 +22,14 @@ func resourceAgentToServer() *schema.Resource {
 			DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
 				// allows port to be optional even for TCP tests
 				// it uses ThousandEyes' default which is 80
-				return newValue == "0"
+				if newValue == "0" {
+					return true
+				}
+				// suppress diff when protocol is ICMP, as port is not used
+				if protocol, ok := d.GetOk("protocol"); ok && protocol == "icmp" {
+					return true
+				}
+				return false
 			},
 		},
 	}

--- a/thousandeyes/resource_agent_to_server_test.go
+++ b/thousandeyes/resource_agent_to_server_test.go
@@ -47,6 +47,28 @@ func TestAccThousandEyesAgentToServer(t *testing.T) {
 				resource.TestCheckResourceAttr(resourceName, "port", "82"),
 			},
 		},
+		{
+			name:                 "tcp_to_icmp_protocol_change",
+			createResourceFile:   "acceptance_resources/agent_to_server/tcp_to_icmp.tf",
+			updateResourceFile:   "acceptance_resources/agent_to_server/icmp_from_tcp.tf",
+			resourceName:         resourceName,
+			checkDestroyFunction: testAccCheckAgentToServerResourceDestroy,
+			checkCreateFunc: []resource.TestCheckFunc{
+				resource.TestCheckResourceAttr(resourceName, "test_name", "UAT - Agent To Server TCP"),
+				resource.TestCheckResourceAttr(resourceName, "server", "api.stg.thousandeyes.com"),
+				resource.TestCheckResourceAttr(resourceName, "protocol", "tcp"),
+				resource.TestCheckResourceAttr(resourceName, "interval", "120"),
+				resource.TestCheckResourceAttr(resourceName, "alerts_enabled", "false"),
+				resource.TestCheckResourceAttr(resourceName, "port", "443"),
+			},
+			checkUpdateFunc: []resource.TestCheckFunc{
+				resource.TestCheckResourceAttr(resourceName, "test_name", "UAT - Agent To Server ICMP"),
+				resource.TestCheckResourceAttr(resourceName, "server", "api.stg.thousandeyes.com"),
+				resource.TestCheckResourceAttr(resourceName, "protocol", "icmp"),
+				resource.TestCheckResourceAttr(resourceName, "interval", "120"),
+				resource.TestCheckResourceAttr(resourceName, "alerts_enabled", "false"),
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/thousandeyes/util.go
+++ b/thousandeyes/util.go
@@ -652,6 +652,18 @@ func resourceFixups[T any](d *schema.ResourceData, structPtr *T) *T {
 		}
 	}
 
+	// When protocol is ICMP, ensure port is explicitly set to nil
+	// This is required when updating from TCP/UDP to ICMP
+	_, hasProtocol := t.FieldByName("Protocol")
+	_, hasPort := t.FieldByName("Port")
+	if hasProtocol && hasPort {
+		protocol, ok := d.GetOk("protocol")
+		if ok && protocol == "icmp" {
+			// Explicitly set port to nil for ICMP tests
+			v.FieldByName("Port").Set(reflect.Zero(v.FieldByName("Port").Type()))
+		}
+	}
+
 	return structPtr
 }
 


### PR DESCRIPTION
**This is a regression, it was previously [fixed on v1](https://github.com/thousandeyes/terraform-provider-thousandeyes/pull/104)**

On v3, for:

1. `agent_to_server` test
2. `protocol=tcp`
3. `port=xxx`

When trying to update the test to have `icmp` protocol, the provider was sending the `port` saved on state, which the API doesn't allow.

The fix: suppress the `port` when `protocol=icmp` and also manipulate the request to send `nil` in case the `port` exists in state.