### PR TITLE
Fix typo in Tag resource documentation

### DIFF
--- a/docs/resources/tag.md
+++ b/docs/resources/tag.md
@@ -6,7 +6,7 @@ description: |-
 
 # thousandeyes_tag (Resource)
 
-This resource provides a tagging system with key/value pairs. It allows you to tag assets within the ThousandEyes platform (such as agents, tests, or alert rules) with meaningful metadata.
+This resource provides a tagging system with key/value pairs. It allows you to tag assets within the ThousandEyes platform (such as agents, tests, or dashboards) with meaningful metadata.
 
 ## Example Usage
 

--- a/thousandeyes/resource_tag.go
+++ b/thousandeyes/resource_tag.go
@@ -21,7 +21,7 @@ func resourceTag() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Description: "This resource provides a tagging system with key/value pairs. It allows you to tag assets within the ThousandEyes platform (such as agents, tests, or alert rules) with meaningful metadata.",
+		Description: "This resource provides a tagging system with key/value pairs. It allows you to tag assets within the ThousandEyes platform (such as agents, tests, or dashboards) with meaningful metadata.",
 	}
 	return &resource
 }


### PR DESCRIPTION
## Summary

This PR fixes a typo in the Tag resource documentation where "alert rules" was incorrectly listed as a supported taggable asset type.

## Changes

- Updated the Tag resource description to correctly reference "dashboards" instead of "alert rules"
- Regenerated documentation to reflect the change

## Details

The Tag resource supports the following object types:
- `test`
- `dashboards`
- `endpoint-test`
- `v-agent`

The documentation previously mentioned "alert rules" which is not a valid taggable object type. This has been corrected to "dashboards" to accurately reflect the API's supported asset types.