### PR TITLE
fix: state upgrade for HttpServerTestRequest

### DIFF
--- a/thousandeyes/schemas/legacy_schema.go
+++ b/thousandeyes/schemas/legacy_schema.go
@@ -81,8 +81,8 @@ func LegacyTestStateUpgrade(ctx context.Context, rawState map[string]any, meta a
 	// This conditional is required because the schema version was introduced on `v3.0.2`.
 	// That means the provider will try to upgrade the state for all versions before that, `v3.0.0|v3.0.1` included.
 	// However, all v3 schemas comply with v7 API, so there is no need to upgrade the state for those versions.
-	// The `links` field was introduced in `v3.0.0` and is present in all test schemas.
-	if _, ok := rawState["links"].(string); !ok {
+	// The `_links` field was introduced in `v3.0.0` and is present in all test schemas.
+	if _, ok := rawState["_links"].(string); !ok {
 
 		if agents, ok := rawState["agents"].([]interface{}); ok {
 			for i, v := range agents {


### PR DESCRIPTION
**Summary**

This PR fixes a mistake in the field name Links for HttpServerTestRequest. See https://github.com/thousandeyes/thousandeyes-sdk-go/blob/v3/tests/model_http_server_test_request.go#L51 

**Changes**

Changes the field name