### PR TITLE
 fix: Add state upgrade for custom headers 

### DIFF
--- a/thousandeyes/schemas/legacy_schema.go
+++ b/thousandeyes/schemas/legacy_schema.go
@@ -2,6 +2,7 @@ package schemas
 
 import (
 	"context"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -72,6 +73,12 @@ func LegacyTestSchema() *schema.Resource {
 					},
 				},
 			},
+			"custom_headers": {
+				Type:        schema.TypeMap,
+				Description: "The custom headers.",
+				Optional:    true,
+				Sensitive:   true,
+			},
 		},
 	}
 }
@@ -129,6 +136,10 @@ func LegacyTestStateUpgrade(ctx context.Context, rawState map[string]any, meta a
 				dnsServer := v.(map[string]interface{})
 				dnsSevers[i] = dnsServer["server_name"]
 			}
+		}
+
+		if _, ok := rawState["custom_headers"].(map[string]interface{}); ok {
+			rawState["custom_headers"] = nil
 		}
 	}
 

--- a/thousandeyes/util_test.go
+++ b/thousandeyes/util_test.go
@@ -555,6 +555,20 @@ func TestFillValue(t *testing.T) {
 		t.Errorf("Expected []int{0,1} for testSlice, but received '%+v' of type %+v", reflect.ValueOf(testSlice), reflect.TypeOf(testSlice))
 	}
 
+	// Map test
+	sourceMap := map[string]interface{}{
+		"alpha": "one",
+		"beta":  "two",
+	}
+	expectedMap := map[string]string{
+		"alpha": "one",
+		"beta":  "two",
+	}
+	testMap := FillValue(sourceMap, map[string]string{}).(map[string]string)
+	if reflect.DeepEqual(testMap, expectedMap) != true {
+		t.Errorf("Expected map[string]string for testMap, but received '%+v' of type %+v", reflect.ValueOf(testMap), reflect.TypeOf(testMap))
+	}
+
 	// Struct test
 	refMap := map[string]string{
 		"field_name": "value foo",


### PR DESCRIPTION
Fixes issue when upgrading state where in some instances `customs_headers` is created as `{}` instead of `null`
Fix mapping of values when target is a map[string]string, as is the case for custom_headers 