### PR TITLE
feat: Add list widget support

### DIFF
--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -173,6 +173,22 @@ resource "thousandeyes_dashboard" "example" {
       }
     }
   }
+
+  widgets {
+    type        = "List"
+    title       = "List Widget"
+    visual_mode = "Full"
+    data_source = "EVENT_DETECTION"
+
+    measure {
+      type = "MEAN"
+    }
+
+    list_config {
+      active_within_value = 7
+      active_within_unit  = "Days"
+    }
+  }
 }
 ```
 

--- a/examples/resources/thousandeyes_dashboard/resource.tf
+++ b/examples/resources/thousandeyes_dashboard/resource.tf
@@ -160,4 +160,20 @@ resource "thousandeyes_dashboard" "example" {
       }
     }
   }
+
+  widgets {
+    type        = "List"
+    title       = "List Widget"
+    visual_mode = "Full"
+    data_source = "EVENT_DETECTION"
+
+    measure {
+      type = "MEAN"
+    }
+
+    list_config {
+      active_within_value = 7
+      active_within_unit  = "Days"
+    }
+  }
 }

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/terraform-plugin-docs v0.21.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.36.1
 	github.com/stretchr/testify v1.8.4
-	github.com/thousandeyes/thousandeyes-sdk-go/v3 v3.0.0-alpha.15
+	github.com/thousandeyes/thousandeyes-sdk-go/v3 v3.0.0-alpha.16
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -193,8 +193,8 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/thousandeyes/thousandeyes-sdk-go/v3 v3.0.0-alpha.15 h1:9ZwzHnqX/6wTWZDcNgN+VsfH+sURoGSXC5weD4Ma3nk=
-github.com/thousandeyes/thousandeyes-sdk-go/v3 v3.0.0-alpha.15/go.mod h1:EWD+kNN2rC06wBi+KB9dIOM+4WJin7VZjqcFSgHF+Ow=
+github.com/thousandeyes/thousandeyes-sdk-go/v3 v3.0.0-alpha.16 h1:trxLKxOWYQrya8gowL4pnYRSmdjHrdRkLUVf7XxaH9s=
+github.com/thousandeyes/thousandeyes-sdk-go/v3 v3.0.0-alpha.16/go.mod h1:EWD+kNN2rC06wBi+KB9dIOM+4WJin7VZjqcFSgHF+Ow=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/thousandeyes/acceptance_resources/dashboard/widget_list_basic.tf
+++ b/thousandeyes/acceptance_resources/dashboard/widget_list_basic.tf
@@ -10,15 +10,9 @@ resource "thousandeyes_dashboard" "test_dashboard_list_widget" {
     title       = "Test List Widget"
     visual_mode = "Full"
     data_source = "EVENT_DETECTION"
-    direction   = "TO_TARGET"
 
     measure {
       type = "MEAN"
-    }
-
-    fixed_timespan {
-      value = 1
-      unit = "Days"
     }
 
     list_config {

--- a/thousandeyes/acceptance_resources/dashboard/widget_list_update.tf
+++ b/thousandeyes/acceptance_resources/dashboard/widget_list_update.tf
@@ -9,16 +9,10 @@ resource "thousandeyes_dashboard" "test_dashboard_list_widget" {
     type        = "List"
     title       = "Test List Widget (Updated)"
     visual_mode = "Full"
-    data_source = "ALERTS"
-    direction   = "TO_TARGET"
+    data_source = "EVENT_DETECTION"
 
     measure {
       type = "MEAN"
-    }
-
-    fixed_timespan {
-      value = 1
-      unit = "Days"
     }
 
     list_config {

--- a/thousandeyes/expand_options.go
+++ b/thousandeyes/expand_options.go
@@ -1,0 +1,46 @@
+package thousandeyes
+
+import (
+	"github.com/thousandeyes/thousandeyes-sdk-go/v3/administrative"
+	"github.com/thousandeyes/thousandeyes-sdk-go/v3/tags"
+	"github.com/thousandeyes/thousandeyes-sdk-go/v3/tests"
+)
+
+func knownExpandTestOptions() []tests.ExpandTestOptions {
+	return filterUnknownEnumValues(
+		tests.AllowedExpandTestOptionsEnumValues,
+		tests.EXPANDTESTOPTIONS_UNKNOWN,
+	)
+}
+
+func knownExpandBgpTestOptions() []tests.ExpandBgpTestOptions {
+	return filterUnknownEnumValues(
+		tests.AllowedExpandBgpTestOptionsEnumValues,
+		tests.EXPANDBGPTESTOPTIONS_UNKNOWN,
+	)
+}
+
+func knownExpandAccountGroupOptions() []administrative.ExpandAccountGroupOptions {
+	return filterUnknownEnumValues(
+		administrative.AllowedExpandAccountGroupOptionsEnumValues,
+		administrative.EXPANDACCOUNTGROUPOPTIONS_UNKNOWN,
+	)
+}
+
+func knownExpandTagsOptions() []tags.ExpandTagsOptions {
+	return filterUnknownEnumValues(
+		tags.AllowedExpandTagsOptionsEnumValues,
+		tags.EXPANDTAGSOPTIONS_UNKNOWN,
+	)
+}
+
+func filterUnknownEnumValues[T comparable](values []T, unknown T) []T {
+	filtered := make([]T, 0, len(values))
+	for _, value := range values {
+		if value == unknown {
+			continue
+		}
+		filtered = append(filtered, value)
+	}
+	return filtered
+}

--- a/thousandeyes/expand_options_test.go
+++ b/thousandeyes/expand_options_test.go
@@ -1,0 +1,17 @@
+package thousandeyes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/thousandeyes/thousandeyes-sdk-go/v3/administrative"
+	"github.com/thousandeyes/thousandeyes-sdk-go/v3/tags"
+	"github.com/thousandeyes/thousandeyes-sdk-go/v3/tests"
+)
+
+func TestKnownExpandOptionsExcludeUnknown(t *testing.T) {
+	assert.NotContains(t, knownExpandTestOptions(), tests.EXPANDTESTOPTIONS_UNKNOWN)
+	assert.NotContains(t, knownExpandBgpTestOptions(), tests.EXPANDBGPTESTOPTIONS_UNKNOWN)
+	assert.NotContains(t, knownExpandAccountGroupOptions(), administrative.EXPANDACCOUNTGROUPOPTIONS_UNKNOWN)
+	assert.NotContains(t, knownExpandTagsOptions(), tags.EXPANDTAGSOPTIONS_UNKNOWN)
+}

--- a/thousandeyes/resource_account_group.go
+++ b/thousandeyes/resource_account_group.go
@@ -30,7 +30,7 @@ func resourceAccountGroupRead(d *schema.ResourceData, m interface{}) error {
 	return GetResource(context.Background(), d, m, func(apiClient *client.APIClient, id string) (interface{}, error) {
 		api := (*administrative.AccountGroupsAPIService)(&apiClient.Common)
 
-		req := api.GetAccountGroup(id).Expand(administrative.AllowedExpandAccountGroupOptionsEnumValues)
+		req := api.GetAccountGroup(id).Expand(knownExpandAccountGroupOptions())
 
 		resp, _, err := req.Execute()
 		return resp, err
@@ -44,7 +44,7 @@ func resourceAccountGroupUpdate(d *schema.ResourceData, m interface{}) error {
 	log.Printf("[INFO] Updating ThousandEyes Account Group %s", d.Id())
 	update := buildAccountGroupStruct(d)
 
-	req := api.UpdateAccountGroup(d.Id()).AccountGroupRequest(*update).Expand(administrative.AllowedExpandAccountGroupOptionsEnumValues)
+	req := api.UpdateAccountGroup(d.Id()).AccountGroupRequest(*update).Expand(knownExpandAccountGroupOptions())
 
 	_, _, err := req.Execute()
 	if err != nil {
@@ -76,7 +76,7 @@ func resourceAccountGroupCreate(d *schema.ResourceData, m interface{}) error {
 	log.Printf("[INFO] Creating ThousandEyes Account Group %s", d.Id())
 	local := buildAccountGroupStruct(d)
 
-	req := api.CreateAccountGroup().AccountGroupRequest(*local).Expand(administrative.AllowedExpandAccountGroupOptionsEnumValues)
+	req := api.CreateAccountGroup().AccountGroupRequest(*local).Expand(knownExpandAccountGroupOptions())
 
 	resp, _, err := req.Execute()
 	if err != nil {

--- a/thousandeyes/resource_agent_to_agent.go
+++ b/thousandeyes/resource_agent_to_agent.go
@@ -49,7 +49,7 @@ func resourceAgentAgentRead(d *schema.ResourceData, m interface{}) error {
 	return GetResource(context.Background(), d, m, func(apiClient *client.APIClient, id string) (interface{}, error) {
 		api := (*tests.AgentToAgentTestsAPIService)(&apiClient.Common)
 
-		req := api.GetAgentToAgentTest(id).Expand(tests.AllowedExpandTestOptionsEnumValues)
+		req := api.GetAgentToAgentTest(id).Expand(knownExpandTestOptions())
 		req = SetAidFromContext(apiClient.GetConfig().Context, req)
 
 		resp, _, err := req.Execute()
@@ -64,7 +64,7 @@ func resourceAgentAgentUpdate(d *schema.ResourceData, m interface{}) error {
 	log.Printf("[INFO] Updating ThousandEyes Test %s", d.Id())
 	update := buildAgentAgentStruct(d)
 
-	req := api.UpdateAgentToAgentTest(d.Id()).AgentToAgentTestRequest(*update).Expand(tests.AllowedExpandTestOptionsEnumValues)
+	req := api.UpdateAgentToAgentTest(d.Id()).AgentToAgentTestRequest(*update).Expand(knownExpandTestOptions())
 	req = SetAidFromContext(apiClient.GetConfig().Context, req)
 
 	_, _, err := req.Execute()
@@ -98,7 +98,7 @@ func resourceAgentAgentCreate(d *schema.ResourceData, m interface{}) error {
 	log.Printf("[INFO] Creating ThousandEyes Test %s", d.Id())
 	local := buildAgentAgentStruct(d)
 
-	req := api.CreateAgentToAgentTest().AgentToAgentTestRequest(*local).Expand(tests.AllowedExpandTestOptionsEnumValues)
+	req := api.CreateAgentToAgentTest().AgentToAgentTestRequest(*local).Expand(knownExpandTestOptions())
 	req = SetAidFromContext(apiClient.GetConfig().Context, req)
 
 	resp, _, err := req.Execute()

--- a/thousandeyes/resource_agent_to_agent_test.go
+++ b/thousandeyes/resource_agent_to_agent_test.go
@@ -87,7 +87,7 @@ func testAccThousandEyesAgentToAgentConfig(testResource string) string {
 
 func getAgentToAgent(id string) (interface{}, error) {
 	api := (*tests.AgentToAgentTestsAPIService)(&testClient.Common)
-	req := api.GetAgentToAgentTest(id).Expand(tests.AllowedExpandTestOptionsEnumValues)
+	req := api.GetAgentToAgentTest(id).Expand(knownExpandTestOptions())
 	req = SetAidFromContext(testClient.GetConfig().Context, req)
 	resp, _, err := req.Execute()
 	return resp, err

--- a/thousandeyes/resource_agent_to_server.go
+++ b/thousandeyes/resource_agent_to_server.go
@@ -60,7 +60,7 @@ func resourceAgentServerRead(d *schema.ResourceData, m interface{}) error {
 	return GetResource(context.Background(), d, m, func(apiClient *client.APIClient, id string) (interface{}, error) {
 		api := (*tests.AgentToServerTestsAPIService)(&apiClient.Common)
 
-		req := api.GetAgentToServerTest(id).Expand(tests.AllowedExpandTestOptionsEnumValues)
+		req := api.GetAgentToServerTest(id).Expand(knownExpandTestOptions())
 		req = SetAidFromContext(apiClient.GetConfig().Context, req)
 
 		resp, _, err := req.Execute()
@@ -75,7 +75,7 @@ func resourceAgentServerUpdate(d *schema.ResourceData, m interface{}) error {
 	log.Printf("[INFO] Updating ThousandEyes Test %s", d.Id())
 	update := buildAgentServerStruct(d)
 
-	req := api.UpdateAgentToServerTest(d.Id()).AgentToServerTestRequest(*update).Expand(tests.AllowedExpandTestOptionsEnumValues)
+	req := api.UpdateAgentToServerTest(d.Id()).AgentToServerTestRequest(*update).Expand(knownExpandTestOptions())
 	req = SetAidFromContext(apiClient.GetConfig().Context, req)
 
 	_, _, err := req.Execute()
@@ -108,7 +108,7 @@ func resourceAgentServerCreate(d *schema.ResourceData, m interface{}) error {
 	log.Printf("[INFO] Creating ThousandEyes Test %s", d.Id())
 	local := buildAgentServerStruct(d)
 
-	req := api.CreateAgentToServerTest().AgentToServerTestRequest(*local).Expand(tests.AllowedExpandTestOptionsEnumValues)
+	req := api.CreateAgentToServerTest().AgentToServerTestRequest(*local).Expand(knownExpandTestOptions())
 	req = SetAidFromContext(apiClient.GetConfig().Context, req)
 
 	resp, _, err := req.Execute()

--- a/thousandeyes/resource_agent_to_server_test.go
+++ b/thousandeyes/resource_agent_to_server_test.go
@@ -113,7 +113,7 @@ func testAccThousandEyesAgentToServerConfig(testResource string) string {
 
 func getAgentToServer(id string) (interface{}, error) {
 	api := (*tests.AgentToServerTestsAPIService)(&testClient.Common)
-	req := api.GetAgentToServerTest(id).Expand(tests.AllowedExpandTestOptionsEnumValues)
+	req := api.GetAgentToServerTest(id).Expand(knownExpandTestOptions())
 	req = SetAidFromContext(testClient.GetConfig().Context, req)
 	resp, _, err := req.Execute()
 	return resp, err

--- a/thousandeyes/resource_api.go
+++ b/thousandeyes/resource_api.go
@@ -30,7 +30,7 @@ func resourceAPIRead(d *schema.ResourceData, m interface{}) error {
 	return GetResource(context.Background(), d, m, func(apiClient *client.APIClient, id string) (interface{}, error) {
 		api := (*tests.APITestsAPIService)(&apiClient.Common)
 
-		req := api.GetApiTest(id).Expand(tests.AllowedExpandTestOptionsEnumValues)
+		req := api.GetApiTest(id).Expand(knownExpandTestOptions())
 		req = SetAidFromContext(apiClient.GetConfig().Context, req)
 
 		resp, _, err := req.Execute()
@@ -45,7 +45,7 @@ func resourceAPIUpdate(d *schema.ResourceData, m interface{}) error {
 	log.Printf("[INFO] Updating ThousandEyes Test %s", d.Id())
 	update := buildAPITestStruct(d)
 
-	req := api.UpdateApiTest(d.Id()).ApiTestRequest(*update).Expand(tests.AllowedExpandTestOptionsEnumValues)
+	req := api.UpdateApiTest(d.Id()).ApiTestRequest(*update).Expand(knownExpandTestOptions())
 	req = SetAidFromContext(apiClient.GetConfig().Context, req)
 
 	_, _, err := req.Execute()
@@ -78,7 +78,7 @@ func resourceAPICreate(d *schema.ResourceData, m interface{}) error {
 	log.Printf("[INFO] Creating ThousandEyes Test %s", d.Id())
 	local := buildAPITestStruct(d)
 
-	req := api.CreateApiTest().ApiTestRequest(*local).Expand(tests.AllowedExpandTestOptionsEnumValues)
+	req := api.CreateApiTest().ApiTestRequest(*local).Expand(knownExpandTestOptions())
 	req = SetAidFromContext(apiClient.GetConfig().Context, req)
 
 	resp, _, err := req.Execute()

--- a/thousandeyes/resource_api_test.go
+++ b/thousandeyes/resource_api_test.go
@@ -163,7 +163,7 @@ func testAccThousandEyesAPIConfig(testResource string) string {
 
 func getAPI(id string) (interface{}, error) {
 	api := (*tests.APITestsAPIService)(&testClient.Common)
-	req := api.GetApiTest(id).Expand(tests.AllowedExpandTestOptionsEnumValues)
+	req := api.GetApiTest(id).Expand(knownExpandTestOptions())
 	req = SetAidFromContext(testClient.GetConfig().Context, req)
 	resp, _, err := req.Execute()
 	return resp, err

--- a/thousandeyes/resource_bgp.go
+++ b/thousandeyes/resource_bgp.go
@@ -38,7 +38,7 @@ func resourceBGPRead(d *schema.ResourceData, m interface{}) error {
 	return GetResource(context.Background(), d, m, func(apiClient *client.APIClient, id string) (interface{}, error) {
 		api := (*tests.BGPTestsAPIService)(&apiClient.Common)
 
-		req := api.GetBgpTest(id).Expand(tests.AllowedExpandBgpTestOptionsEnumValues)
+		req := api.GetBgpTest(id).Expand(knownExpandBgpTestOptions())
 		req = SetAidFromContext(apiClient.GetConfig().Context, req)
 
 		resp, _, err := req.Execute()
@@ -53,7 +53,7 @@ func resourceBGPUpdate(d *schema.ResourceData, m interface{}) error {
 	log.Printf("[INFO] Updating ThousandEyes Test %s", d.Id())
 	update := buildUpdateBGPStruct(d)
 
-	req := api.UpdateBgpTest(d.Id()).UpdateBgpTestRequest(*update).Expand(tests.AllowedExpandBgpTestOptionsEnumValues)
+	req := api.UpdateBgpTest(d.Id()).UpdateBgpTestRequest(*update).Expand(knownExpandBgpTestOptions())
 	req = SetAidFromContext(apiClient.GetConfig().Context, req)
 
 	_, _, err := req.Execute()
@@ -88,7 +88,7 @@ func resourceBGPCreate(d *schema.ResourceData, m interface{}) error {
 	log.Printf("[INFO] Creating ThousandEyes Test %s", d.Id())
 	local := buildBGPStruct(d)
 
-	req := api.CreateBgpTest().BgpTestRequest(*local).Expand(tests.AllowedExpandBgpTestOptionsEnumValues)
+	req := api.CreateBgpTest().BgpTestRequest(*local).Expand(knownExpandBgpTestOptions())
 	req = SetAidFromContext(apiClient.GetConfig().Context, req)
 
 	resp, _, err := req.Execute()

--- a/thousandeyes/resource_dashboard_test.go
+++ b/thousandeyes/resource_dashboard_test.go
@@ -28,7 +28,7 @@ func TestAccThousandEyesDashboard(t *testing.T) {
 	var resourceNameFilterWidget = "thousandeyes_dashboard.test_dashboard_filter_widget"
 	var resourceNameNumberDefaults = "thousandeyes_dashboard.test_dashboard_number_defaults"
 	var resourceNameNumberWidget = "thousandeyes_dashboard.test_dashboard_number_widget"
-	//var resourceNameListWidget = "thousandeyes_dashboard.test_dashboard_list_widget"
+	var resourceNameListWidget = "thousandeyes_dashboard.test_dashboard_list_widget"
 	var testCases = []struct {
 		name                 string
 		createResourceFile   string
@@ -109,6 +109,7 @@ func TestAccThousandEyesDashboard(t *testing.T) {
 				resource.TestCheckResourceAttr(resourceNameMapWidget, "widgets.0.type", "Map"),
 				resource.TestCheckResourceAttr(resourceNameMapWidget, "widgets.0.title", "Test Map Widget"),
 				resource.TestCheckResourceAttr(resourceNameMapWidget, "widgets.0.visual_mode", "Full"),
+				resource.TestCheckResourceAttr(resourceNameMapWidget, "widgets.0.is_embedded", "false"),
 				resource.TestCheckResourceAttr(resourceNameMapWidget, "widgets.0.geo_map_config.0.min_scale", "0"),
 				resource.TestCheckResourceAttr(resourceNameMapWidget, "widgets.0.geo_map_config.0.max_scale", "100"),
 				resource.TestCheckResourceAttr(resourceNameMapWidget, "widgets.0.geo_map_config.0.group_by", "COUNTRY"),
@@ -120,6 +121,7 @@ func TestAccThousandEyesDashboard(t *testing.T) {
 				resource.TestCheckResourceAttr(resourceNameMapWidget, "widgets.0.type", "Map"),
 				resource.TestCheckResourceAttr(resourceNameMapWidget, "widgets.0.title", "Test Map Widget (Updated)"),
 				resource.TestCheckResourceAttr(resourceNameMapWidget, "widgets.0.visual_mode", "Full"),
+				resource.TestCheckResourceAttr(resourceNameMapWidget, "widgets.0.is_embedded", "false"),
 				resource.TestCheckResourceAttr(resourceNameMapWidget, "widgets.0.geo_map_config.0.min_scale", "10"),
 				resource.TestCheckResourceAttr(resourceNameMapWidget, "widgets.0.geo_map_config.0.max_scale", "200"),
 				resource.TestCheckResourceAttr(resourceNameMapWidget, "widgets.0.geo_map_config.0.group_by", "CONTINENT"),
@@ -467,44 +469,35 @@ func TestAccThousandEyesDashboard(t *testing.T) {
 				resource.TestCheckResourceAttr(resourceNameNumberWidget, "widgets.0.number_cards.1.measure.0.type", "TOTAL"),
 			},
 		},
-		// This API is return invalid sortDirection
-		//  "sortDirection": "ASC",
-		// The expected values according to the docs
-		// sortDirection: LegacyWidgetSortDirection (Deprecated) Specifies the order in which cards are sorted.
-		// enum = ["Ascending", "Descending"]
-		//{
-		//	name:                 "create_update_delete_dashboard_list_widget_test",
-		//	createResourceFile:   "acceptance_resources/dashboard/widget_list_basic.tf",
-		//	updateResourceFile:   "acceptance_resources/dashboard/widget_list_update.tf",
-		//	resourceName:         resourceNameListWidget,
-		//	checkDestroyFunction: testAccCheckDashboardResourceDestroy,
-		//	checkCreateFunc: []resource.TestCheckFunc{
-		//		resource.TestCheckResourceAttr(resourceNameListWidget, "title", "Test Dashboard List Widget"),
-		//		resource.TestCheckResourceAttr(resourceNameListWidget, "description", "Test Dashboard with List Widget"),
-		//		resource.TestCheckResourceAttr(resourceNameListWidget, "widgets.0.type", "List"),
-		//		resource.TestCheckResourceAttr(resourceNameListWidget, "widgets.0.title", "Test List Widget"),
-		//		resource.TestCheckResourceAttr(resourceNameListWidget, "widgets.0.visual_mode", "Full"),
-		//		resource.TestCheckResourceAttr(resourceNameListWidget, "widgets.0.data_source", "EVENT_DETECTION"),
-		//		resource.TestCheckResourceAttr(resourceNameListWidget, "widgets.0.measure.0.type", "MEAN"),
-		//		resource.TestCheckResourceAttr(resourceNameListWidget, "widgets.0.fixed_timespan.0.value", "1"),
-		//		resource.TestCheckResourceAttr(resourceNameListWidget, "widgets.0.fixed_timespan.0.unit", "Days"),
-		//		resource.TestCheckResourceAttr(resourceNameListWidget, "widgets.0.list_config.0.active_within_value", "7"),
-		//		resource.TestCheckResourceAttr(resourceNameListWidget, "widgets.0.list_config.0.active_within_unit", "Days"),
-		//	},
-		//	checkUpdateFunc: []resource.TestCheckFunc{
-		//		resource.TestCheckResourceAttr(resourceNameListWidget, "title", "Test Dashboard List Widget (Updated)"),
-		//		resource.TestCheckResourceAttr(resourceNameListWidget, "description", "Test Dashboard with List Widget (Updated)"),
-		//		resource.TestCheckResourceAttr(resourceNameListWidget, "widgets.0.type", "List"),
-		//		resource.TestCheckResourceAttr(resourceNameListWidget, "widgets.0.title", "Test List Widget (Updated)"),
-		//		resource.TestCheckResourceAttr(resourceNameListWidget, "widgets.0.visual_mode", "Full"),
-		//		resource.TestCheckResourceAttr(resourceNameListWidget, "widgets.0.data_source", "ALERTS"),
-		//		resource.TestCheckResourceAttr(resourceNameListWidget, "widgets.0.measure.0.type", "MEAN"),
-		//		resource.TestCheckResourceAttr(resourceNameListWidget, "widgets.0.fixed_timespan.0.value", "1"),
-		//		resource.TestCheckResourceAttr(resourceNameListWidget, "widgets.0.fixed_timespan.0.unit", "Days"),
-		//		resource.TestCheckResourceAttr(resourceNameListWidget, "widgets.0.list_config.0.active_within_value", "14"),
-		//		resource.TestCheckResourceAttr(resourceNameListWidget, "widgets.0.list_config.0.active_within_unit", "Days"),
-		//	},
-		//},
+		{
+			name:                 "create_update_delete_dashboard_list_widget_test",
+			createResourceFile:   "acceptance_resources/dashboard/widget_list_basic.tf",
+			updateResourceFile:   "acceptance_resources/dashboard/widget_list_update.tf",
+			resourceName:         resourceNameListWidget,
+			checkDestroyFunction: testAccCheckDashboardResourceDestroy,
+			checkCreateFunc: []resource.TestCheckFunc{
+				resource.TestCheckResourceAttr(resourceNameListWidget, "title", "Test Dashboard List Widget"),
+				resource.TestCheckResourceAttr(resourceNameListWidget, "description", "Test Dashboard with List Widget"),
+				resource.TestCheckResourceAttr(resourceNameListWidget, "widgets.0.type", "List"),
+				resource.TestCheckResourceAttr(resourceNameListWidget, "widgets.0.title", "Test List Widget"),
+				resource.TestCheckResourceAttr(resourceNameListWidget, "widgets.0.visual_mode", "Full"),
+				resource.TestCheckResourceAttr(resourceNameListWidget, "widgets.0.data_source", "EVENT_DETECTION"),
+				resource.TestCheckResourceAttr(resourceNameListWidget, "widgets.0.measure.0.type", "MEAN"),
+				resource.TestCheckResourceAttr(resourceNameListWidget, "widgets.0.list_config.0.active_within_value", "7"),
+				resource.TestCheckResourceAttr(resourceNameListWidget, "widgets.0.list_config.0.active_within_unit", "Days"),
+			},
+			checkUpdateFunc: []resource.TestCheckFunc{
+				resource.TestCheckResourceAttr(resourceNameListWidget, "title", "Test Dashboard List Widget (Updated)"),
+				resource.TestCheckResourceAttr(resourceNameListWidget, "description", "Test Dashboard with List Widget (Updated)"),
+				resource.TestCheckResourceAttr(resourceNameListWidget, "widgets.0.type", "List"),
+				resource.TestCheckResourceAttr(resourceNameListWidget, "widgets.0.title", "Test List Widget (Updated)"),
+				resource.TestCheckResourceAttr(resourceNameListWidget, "widgets.0.visual_mode", "Full"),
+				resource.TestCheckResourceAttr(resourceNameListWidget, "widgets.0.data_source", "EVENT_DETECTION"),
+				resource.TestCheckResourceAttr(resourceNameListWidget, "widgets.0.measure.0.type", "MEAN"),
+				resource.TestCheckResourceAttr(resourceNameListWidget, "widgets.0.list_config.0.active_within_value", "14"),
+				resource.TestCheckResourceAttr(resourceNameListWidget, "widgets.0.list_config.0.active_within_unit", "Days"),
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/thousandeyes/resource_dns_server.go
+++ b/thousandeyes/resource_dns_server.go
@@ -39,7 +39,7 @@ func resourceDNSServerRead(d *schema.ResourceData, m interface{}) error {
 	return GetResource(context.Background(), d, m, func(apiClient *client.APIClient, id string) (interface{}, error) {
 		api := (*tests.DNSServerTestsAPIService)(&apiClient.Common)
 
-		req := api.GetDnsServerTest(id).Expand(tests.AllowedExpandTestOptionsEnumValues)
+		req := api.GetDnsServerTest(id).Expand(knownExpandTestOptions())
 		req = SetAidFromContext(apiClient.GetConfig().Context, req)
 
 		resp, _, err := req.Execute()
@@ -58,7 +58,7 @@ func resourceDNSServerUpdate(d *schema.ResourceData, m interface{}) error {
 		update.Domain = fmt.Sprintf("%s ANY", update.Domain)
 	}
 
-	req := api.UpdateDnsServerTest(d.Id()).DnsServerTestRequest(*update).Expand(tests.AllowedExpandTestOptionsEnumValues)
+	req := api.UpdateDnsServerTest(d.Id()).DnsServerTestRequest(*update).Expand(knownExpandTestOptions())
 	req = SetAidFromContext(apiClient.GetConfig().Context, req)
 
 	_, _, err := req.Execute()
@@ -91,7 +91,7 @@ func resourceDNSServerCreate(d *schema.ResourceData, m interface{}) error {
 	log.Printf("[INFO] Creating ThousandEyes Test %s", d.Id())
 	local := buildDNSServerStruct(d)
 
-	req := api.CreateDnsServerTest().DnsServerTestRequest(*local).Expand(tests.AllowedExpandTestOptionsEnumValues)
+	req := api.CreateDnsServerTest().DnsServerTestRequest(*local).Expand(knownExpandTestOptions())
 	req = SetAidFromContext(apiClient.GetConfig().Context, req)
 
 	resp, _, err := req.Execute()

--- a/thousandeyes/resource_dns_server_test.go
+++ b/thousandeyes/resource_dns_server_test.go
@@ -90,7 +90,7 @@ func testAccThousandEyesDNSServerConfig(testResource string) string {
 
 func getDNSServer(id string) (interface{}, error) {
 	api := (*tests.DNSServerTestsAPIService)(&testClient.Common)
-	req := api.GetDnsServerTest(id).Expand(tests.AllowedExpandTestOptionsEnumValues)
+	req := api.GetDnsServerTest(id).Expand(knownExpandTestOptions())
 	req = SetAidFromContext(testClient.GetConfig().Context, req)
 	resp, _, err := req.Execute()
 	return resp, err

--- a/thousandeyes/resource_dns_trace.go
+++ b/thousandeyes/resource_dns_trace.go
@@ -39,7 +39,7 @@ func resourceDNSTraceRead(d *schema.ResourceData, m interface{}) error {
 	return GetResource(context.Background(), d, m, func(apiClient *client.APIClient, id string) (interface{}, error) {
 		api := (*tests.DNSTraceTestsAPIService)(&apiClient.Common)
 
-		req := api.GetDnsTraceTest(id).Expand(tests.AllowedExpandTestOptionsEnumValues)
+		req := api.GetDnsTraceTest(id).Expand(knownExpandTestOptions())
 		req = SetAidFromContext(apiClient.GetConfig().Context, req)
 
 		resp, _, err := req.Execute()
@@ -58,7 +58,7 @@ func resourceDNSTraceUpdate(d *schema.ResourceData, m interface{}) error {
 		update.Domain = fmt.Sprintf("%s ANY", update.Domain)
 	}
 
-	req := api.UpdateDnsTraceTest(d.Id()).DnsTraceTestRequest(*update).Expand(tests.AllowedExpandTestOptionsEnumValues)
+	req := api.UpdateDnsTraceTest(d.Id()).DnsTraceTestRequest(*update).Expand(knownExpandTestOptions())
 	req = SetAidFromContext(apiClient.GetConfig().Context, req)
 
 	_, _, err := req.Execute()
@@ -91,7 +91,7 @@ func resourceDNSTraceCreate(d *schema.ResourceData, m interface{}) error {
 	log.Printf("[INFO] Creating ThousandEyes Test %s", d.Id())
 	local := buildDNSTraceStruct(d)
 
-	req := api.CreateDnsTraceTest().DnsTraceTestRequest(*local).Expand(tests.AllowedExpandTestOptionsEnumValues)
+	req := api.CreateDnsTraceTest().DnsTraceTestRequest(*local).Expand(knownExpandTestOptions())
 	req = SetAidFromContext(apiClient.GetConfig().Context, req)
 
 	resp, _, err := req.Execute()

--- a/thousandeyes/resource_dns_trace_test.go
+++ b/thousandeyes/resource_dns_trace_test.go
@@ -85,7 +85,7 @@ func testAccThousandEyesDNSTraceConfig(testResource string) string {
 
 func getDNSTrace(id string) (interface{}, error) {
 	api := (*tests.DNSTraceTestsAPIService)(&testClient.Common)
-	req := api.GetDnsTraceTest(id).Expand(tests.AllowedExpandTestOptionsEnumValues)
+	req := api.GetDnsTraceTest(id).Expand(knownExpandTestOptions())
 	req = SetAidFromContext(testClient.GetConfig().Context, req)
 	resp, _, err := req.Execute()
 	return resp, err

--- a/thousandeyes/resource_dnssec.go
+++ b/thousandeyes/resource_dnssec.go
@@ -39,7 +39,7 @@ func resourceDNSSecRead(d *schema.ResourceData, m interface{}) error {
 	return GetResource(context.Background(), d, m, func(apiClient *client.APIClient, id string) (interface{}, error) {
 		api := (*tests.DNSSECTestsAPIService)(&apiClient.Common)
 
-		req := api.GetDnsSecTest(id).Expand(tests.AllowedExpandTestOptionsEnumValues)
+		req := api.GetDnsSecTest(id).Expand(knownExpandTestOptions())
 		req = SetAidFromContext(apiClient.GetConfig().Context, req)
 
 		resp, _, err := req.Execute()
@@ -58,7 +58,7 @@ func resourceDNSSecUpdate(d *schema.ResourceData, m interface{}) error {
 		update.Domain = fmt.Sprintf("%s ANY", update.Domain)
 	}
 
-	req := api.UpdateDnsSecTest(d.Id()).DnsSecTestRequest(*update).Expand(tests.AllowedExpandTestOptionsEnumValues)
+	req := api.UpdateDnsSecTest(d.Id()).DnsSecTestRequest(*update).Expand(knownExpandTestOptions())
 	req = SetAidFromContext(apiClient.GetConfig().Context, req)
 
 	_, _, err := req.Execute()
@@ -91,7 +91,7 @@ func resourceDNSSecCreate(d *schema.ResourceData, m interface{}) error {
 	log.Printf("[INFO] Creating ThousandEyes Test %s", d.Id())
 	local := buildDNSSecStruct(d)
 
-	req := api.CreateDnsSecTest().DnsSecTestRequest(*local).Expand(tests.AllowedExpandTestOptionsEnumValues)
+	req := api.CreateDnsSecTest().DnsSecTestRequest(*local).Expand(knownExpandTestOptions())
 	req = SetAidFromContext(apiClient.GetConfig().Context, req)
 
 	resp, _, err := req.Execute()

--- a/thousandeyes/resource_dnssec_test.go
+++ b/thousandeyes/resource_dnssec_test.go
@@ -85,7 +85,7 @@ func testAccThousandEyesDNSSECConfig(testResource string) string {
 
 func getDNSSEC(id string) (interface{}, error) {
 	api := (*tests.DNSSECTestsAPIService)(&testClient.Common)
-	req := api.GetDnsSecTest(id).Expand(tests.AllowedExpandTestOptionsEnumValues)
+	req := api.GetDnsSecTest(id).Expand(knownExpandTestOptions())
 	req = SetAidFromContext(testClient.GetConfig().Context, req)
 	resp, _, err := req.Execute()
 	return resp, err

--- a/thousandeyes/resource_ftp_server.go
+++ b/thousandeyes/resource_ftp_server.go
@@ -40,7 +40,7 @@ func resourceFTPServerRead(d *schema.ResourceData, m interface{}) error {
 	return GetResource(context.Background(), d, m, func(apiClient *client.APIClient, id string) (interface{}, error) {
 		api := (*tests.FTPServerTestsAPIService)(&apiClient.Common)
 
-		req := api.GetFtpServerTest(id).Expand(tests.AllowedExpandTestOptionsEnumValues)
+		req := api.GetFtpServerTest(id).Expand(knownExpandTestOptions())
 		req = SetAidFromContext(apiClient.GetConfig().Context, req)
 
 		resp, _, err := req.Execute()
@@ -55,7 +55,7 @@ func resourceFTPServerUpdate(d *schema.ResourceData, m interface{}) error {
 	log.Printf("[INFO] Updating ThousandEyes Test %s", d.Id())
 	update := buildFTPServerStruct(d)
 
-	req := api.UpdateFtpServerTest(d.Id()).FtpServerTestRequest(*update).Expand(tests.AllowedExpandTestOptionsEnumValues)
+	req := api.UpdateFtpServerTest(d.Id()).FtpServerTestRequest(*update).Expand(knownExpandTestOptions())
 	req = SetAidFromContext(apiClient.GetConfig().Context, req)
 
 	_, _, err := req.Execute()
@@ -88,7 +88,7 @@ func resourceFTPServerCreate(d *schema.ResourceData, m interface{}) error {
 	log.Printf("[INFO] Creating ThousandEyes Test %s", d.Id())
 	local := buildFTPServerStruct(d)
 
-	req := api.CreateFtpServerTest().FtpServerTestRequest(*local).Expand(tests.AllowedExpandTestOptionsEnumValues)
+	req := api.CreateFtpServerTest().FtpServerTestRequest(*local).Expand(knownExpandTestOptions())
 	req = SetAidFromContext(apiClient.GetConfig().Context, req)
 
 	resp, _, err := req.Execute()

--- a/thousandeyes/resource_ftp_server_test.go
+++ b/thousandeyes/resource_ftp_server_test.go
@@ -98,7 +98,7 @@ func testAccThousandEyesFTPServerConfig(testResource string) string {
 
 func getFTPServer(id string) (interface{}, error) {
 	api := (*tests.FTPServerTestsAPIService)(&testClient.Common)
-	req := api.GetFtpServerTest(id).Expand(tests.AllowedExpandTestOptionsEnumValues)
+	req := api.GetFtpServerTest(id).Expand(knownExpandTestOptions())
 	req = SetAidFromContext(testClient.GetConfig().Context, req)
 	resp, _, err := req.Execute()
 	return resp, err

--- a/thousandeyes/resource_http_server.go
+++ b/thousandeyes/resource_http_server.go
@@ -49,7 +49,7 @@ func resourceHTTPServerRead(d *schema.ResourceData, m interface{}) error {
 	log.Printf("[INFO] Reading Thousandeyes Resource %s", d.Id())
 
 	api := (*tests.HTTPServerTestsAPIService)(&apiClient.Common)
-	req := api.GetHttpServerTest(d.Id()).Expand(tests.AllowedExpandTestOptionsEnumValues)
+	req := api.GetHttpServerTest(d.Id()).Expand(knownExpandTestOptions())
 	req = SetAidFromContext(apiClient.GetConfig().Context, req)
 
 	resp, _, err := req.Execute()
@@ -110,7 +110,7 @@ func resourceHTTPServerUpdate(d *schema.ResourceData, m interface{}) error {
 	log.Printf("[INFO] Updating ThousandEyes Test %s", d.Id())
 	update := buildHTTPServerStruct(d)
 
-	req := api.UpdateHttpServerTest(d.Id()).HttpServerTestRequest(*update).Expand(tests.AllowedExpandTestOptionsEnumValues)
+	req := api.UpdateHttpServerTest(d.Id()).HttpServerTestRequest(*update).Expand(knownExpandTestOptions())
 	req = SetAidFromContext(apiClient.GetConfig().Context, req)
 
 	_, _, err := req.Execute()
@@ -143,7 +143,7 @@ func resourceHTTPServerCreate(d *schema.ResourceData, m interface{}) error {
 	log.Printf("[INFO] Creating ThousandEyes Test %s", d.Id())
 	local := buildHTTPServerStruct(d)
 
-	req := api.CreateHttpServerTest().HttpServerTestRequest(*local).Expand(tests.AllowedExpandTestOptionsEnumValues)
+	req := api.CreateHttpServerTest().HttpServerTestRequest(*local).Expand(knownExpandTestOptions())
 	req = SetAidFromContext(apiClient.GetConfig().Context, req)
 
 	resp, _, err := req.Execute()

--- a/thousandeyes/resource_http_server_test.go
+++ b/thousandeyes/resource_http_server_test.go
@@ -85,7 +85,7 @@ func testAccThousandEyesHTTPServerConfig(testResource string) string {
 
 func getHttpServer(id string) (interface{}, error) {
 	api := (*tests.HTTPServerTestsAPIService)(&testClient.Common)
-	req := api.GetHttpServerTest(id).Expand(tests.AllowedExpandTestOptionsEnumValues)
+	req := api.GetHttpServerTest(id).Expand(knownExpandTestOptions())
 	req = SetAidFromContext(testClient.GetConfig().Context, req)
 	resp, _, err := req.Execute()
 	return resp, err

--- a/thousandeyes/resource_page_load.go
+++ b/thousandeyes/resource_page_load.go
@@ -40,7 +40,7 @@ func resourcePageLoadRead(ctx context.Context, d *schema.ResourceData, m interfa
 		GetResource(context.Background(), d, m, func(apiClient *client.APIClient, id string) (interface{}, error) {
 			api := (*tests.PageLoadTestsAPIService)(&apiClient.Common)
 
-			req := api.GetPageLoadTest(id).Expand(tests.AllowedExpandTestOptionsEnumValues)
+			req := api.GetPageLoadTest(id).Expand(knownExpandTestOptions())
 			req = SetAidFromContext(apiClient.GetConfig().Context, req)
 
 			resp, _, err := req.Execute()
@@ -56,7 +56,7 @@ func resourcePageLoadUpdate(ctx context.Context, d *schema.ResourceData, m inter
 	log.Printf("[INFO] Updating ThousandEyes Test %s", d.Id())
 	update := buildPageLoadStruct(d)
 
-	req := api.UpdatePageLoadTest(d.Id()).PageLoadTestRequest(*update).Expand(tests.AllowedExpandTestOptionsEnumValues)
+	req := api.UpdatePageLoadTest(d.Id()).PageLoadTestRequest(*update).Expand(knownExpandTestOptions())
 	req = SetAidFromContext(apiClient.GetConfig().Context, req)
 
 	_, _, err := req.Execute()
@@ -89,7 +89,7 @@ func resourcePageLoadCreate(ctx context.Context, d *schema.ResourceData, m inter
 	log.Printf("[INFO] Creating ThousandEyes Test %s", d.Id())
 	local := buildPageLoadStruct(d)
 
-	req := api.CreatePageLoadTest().PageLoadTestRequest(*local).Expand(tests.AllowedExpandTestOptionsEnumValues)
+	req := api.CreatePageLoadTest().PageLoadTestRequest(*local).Expand(knownExpandTestOptions())
 	req = SetAidFromContext(apiClient.GetConfig().Context, req)
 
 	resp, _, err := req.Execute()

--- a/thousandeyes/resource_page_load_test.go
+++ b/thousandeyes/resource_page_load_test.go
@@ -87,7 +87,7 @@ func testAccThousandEyesPageLoadConfig(testResource string) string {
 
 func getPageLoad(id string) (interface{}, error) {
 	api := (*tests.PageLoadTestsAPIService)(&testClient.Common)
-	req := api.GetPageLoadTest(id).Expand(tests.AllowedExpandTestOptionsEnumValues)
+	req := api.GetPageLoadTest(id).Expand(knownExpandTestOptions())
 	req = SetAidFromContext(testClient.GetConfig().Context, req)
 	resp, _, err := req.Execute()
 	return resp, err

--- a/thousandeyes/resource_sip_server.go
+++ b/thousandeyes/resource_sip_server.go
@@ -38,7 +38,7 @@ func resourceSIPServerRead(d *schema.ResourceData, m interface{}) error {
 	return GetResource(context.Background(), d, m, func(apiClient *client.APIClient, id string) (interface{}, error) {
 		api := (*tests.SIPServerTestsAPIService)(&apiClient.Common)
 
-		req := api.GetSipServerTest(id).Expand(tests.AllowedExpandTestOptionsEnumValues)
+		req := api.GetSipServerTest(id).Expand(knownExpandTestOptions())
 		req = SetAidFromContext(apiClient.GetConfig().Context, req)
 
 		resp, _, err := req.Execute()
@@ -61,7 +61,7 @@ func resourceSIPServerUpdate(d *schema.ResourceData, m interface{}) error {
 	// without being rejected.
 	fullUpdate := buildSIPServerStruct(d)
 	update.TargetSipCredentials = fullUpdate.TargetSipCredentials
-	req := api.UpdateSipServerTest(d.Id()).SipServerTestRequest(*update).Expand(tests.AllowedExpandTestOptionsEnumValues)
+	req := api.UpdateSipServerTest(d.Id()).SipServerTestRequest(*update).Expand(knownExpandTestOptions())
 	req = SetAidFromContext(apiClient.GetConfig().Context, req)
 
 	if _, _, err := req.Execute(); err != nil {
@@ -93,7 +93,7 @@ func resourceSIPServerCreate(d *schema.ResourceData, m interface{}) error {
 	log.Printf("[INFO] Creating ThousandEyes Test %s", d.Id())
 	local := buildSIPServerStruct(d)
 
-	req := api.CreateSipServerTest().SipServerTestRequest(*local).Expand(tests.AllowedExpandTestOptionsEnumValues)
+	req := api.CreateSipServerTest().SipServerTestRequest(*local).Expand(knownExpandTestOptions())
 	req = SetAidFromContext(apiClient.GetConfig().Context, req)
 
 	resp, _, err := req.Execute()

--- a/thousandeyes/resource_sip_server_test.go
+++ b/thousandeyes/resource_sip_server_test.go
@@ -91,7 +91,7 @@ func testAccThousandEyesSIPServerConfig(testResource string) string {
 
 func getSIPServer(id string) (interface{}, error) {
 	api := (*tests.SIPServerTestsAPIService)(&testClient.Common)
-	req := api.GetSipServerTest(id).Expand(tests.AllowedExpandTestOptionsEnumValues)
+	req := api.GetSipServerTest(id).Expand(knownExpandTestOptions())
 	req = SetAidFromContext(testClient.GetConfig().Context, req)
 	resp, _, err := req.Execute()
 	return resp, err

--- a/thousandeyes/resource_tag_assignment.go
+++ b/thousandeyes/resource_tag_assignment.go
@@ -31,7 +31,7 @@ func resourceTagAssignmentRead(d *schema.ResourceData, m interface{}) error {
 	return GetResource(context.Background(), d, m, func(apiClient *client.APIClient, id string) (interface{}, error) {
 		api := (*tags.TagsAPIService)(&apiClient.Common)
 
-		req := api.GetTag(id).Expand(tags.AllowedExpandTagsOptionsEnumValues)
+		req := api.GetTag(id).Expand(knownExpandTagsOptions())
 		req = SetAidFromContext(apiClient.GetConfig().Context, req)
 
 		resp, _, err := req.Execute()

--- a/thousandeyes/resource_tag_test.go
+++ b/thousandeyes/resource_tag_test.go
@@ -164,7 +164,7 @@ func testAccThousandEyesTagConfig(testResource string) string {
 
 func getTag(id string) (*tags.Tag, error) {
 	api := (*tags.TagsAPIService)(&testClient.Common)
-	req := api.GetTag(id).Expand(tags.AllowedExpandTagsOptionsEnumValues)
+	req := api.GetTag(id).Expand(knownExpandTagsOptions())
 	req = SetAidFromContext(testClient.GetConfig().Context, req)
 	resp, _, err := req.Execute()
 	return resp, err

--- a/thousandeyes/resource_voice.go
+++ b/thousandeyes/resource_voice.go
@@ -38,7 +38,7 @@ func resourceRTPStreamRead(d *schema.ResourceData, m interface{}) error {
 	return GetResource(context.Background(), d, m, func(apiClient *client.APIClient, id string) (interface{}, error) {
 		api := (*tests.VoiceTestsAPIService)(&apiClient.Common)
 
-		req := api.GetVoiceTest(id).Expand(tests.AllowedExpandTestOptionsEnumValues)
+		req := api.GetVoiceTest(id).Expand(knownExpandTestOptions())
 		req = SetAidFromContext(apiClient.GetConfig().Context, req)
 
 		resp, _, err := req.Execute()
@@ -53,7 +53,7 @@ func resourceRTPStreamUpdate(d *schema.ResourceData, m interface{}) error {
 	log.Printf("[INFO] Updating ThousandEyes Test %s", d.Id())
 	update := buildRTPStreamStruct(d)
 
-	req := api.UpdateVoiceTest(d.Id()).VoiceTestRequest(*update).Expand(tests.AllowedExpandTestOptionsEnumValues)
+	req := api.UpdateVoiceTest(d.Id()).VoiceTestRequest(*update).Expand(knownExpandTestOptions())
 	req = SetAidFromContext(apiClient.GetConfig().Context, req)
 
 	_, _, err := req.Execute()
@@ -86,7 +86,7 @@ func resourceRTPStreamCreate(d *schema.ResourceData, m interface{}) error {
 	log.Printf("[INFO] Creating ThousandEyes Test %s", d.Id())
 	local := buildRTPStreamStruct(d)
 
-	req := api.CreateVoiceTest().VoiceTestRequest(*local).Expand(tests.AllowedExpandTestOptionsEnumValues)
+	req := api.CreateVoiceTest().VoiceTestRequest(*local).Expand(knownExpandTestOptions())
 	req = SetAidFromContext(apiClient.GetConfig().Context, req)
 
 	resp, _, err := req.Execute()

--- a/thousandeyes/resource_voice_test.go
+++ b/thousandeyes/resource_voice_test.go
@@ -83,7 +83,7 @@ func testAccThousandEyesVoiceConfig(testResource string) string {
 
 func getRTPStream(id string) (interface{}, error) {
 	api := (*tests.VoiceTestsAPIService)(&testClient.Common)
-	req := api.GetVoiceTest(id).Expand(tests.AllowedExpandTestOptionsEnumValues)
+	req := api.GetVoiceTest(id).Expand(knownExpandTestOptions())
 	req = SetAidFromContext(testClient.GetConfig().Context, req)
 	resp, _, err := req.Execute()
 	return resp, err

--- a/thousandeyes/resource_web_transactions.go
+++ b/thousandeyes/resource_web_transactions.go
@@ -42,7 +42,7 @@ func resourceWebTransactionRead(ctx context.Context, d *schema.ResourceData, m i
 		GetResource(ctx, d, m, func(apiClient *client.APIClient, id string) (interface{}, error) {
 			api := (*tests.WebTransactionTestsAPIService)(&apiClient.Common)
 
-			req := api.GetWebTransactionsTest(id).Expand(tests.AllowedExpandTestOptionsEnumValues)
+			req := api.GetWebTransactionsTest(id).Expand(knownExpandTestOptions())
 			req = SetAidFromContext(apiClient.GetConfig().Context, req)
 
 			resp, _, err := req.Execute()
@@ -58,7 +58,7 @@ func resourceWebTransactionUpdate(ctx context.Context, d *schema.ResourceData, m
 	log.Printf("[INFO] Updating ThousandEyes Test %s", d.Id())
 	update := buildWebTransactionStruct(d)
 
-	req := api.UpdateWebTransactionsTest(d.Id()).WebTransactionTestRequest(*update).Expand(tests.AllowedExpandTestOptionsEnumValues)
+	req := api.UpdateWebTransactionsTest(d.Id()).WebTransactionTestRequest(*update).Expand(knownExpandTestOptions())
 	req = SetAidFromContext(apiClient.GetConfig().Context, req)
 
 	_, _, err := req.Execute()
@@ -91,7 +91,7 @@ func resourceWebTransactionCreate(ctx context.Context, d *schema.ResourceData, m
 	log.Printf("[INFO] Creating ThousandEyes Test %s", d.Id())
 	local := buildWebTransactionStruct(d)
 
-	req := api.CreateWebTransactionsTest().WebTransactionTestRequest(*local).Expand(tests.AllowedExpandTestOptionsEnumValues)
+	req := api.CreateWebTransactionsTest().WebTransactionTestRequest(*local).Expand(knownExpandTestOptions())
 	req = SetAidFromContext(apiClient.GetConfig().Context, req)
 
 	resp, _, err := req.Execute()

--- a/thousandeyes/resource_web_transactions_test.go
+++ b/thousandeyes/resource_web_transactions_test.go
@@ -93,7 +93,7 @@ func testAccThousandEyesWebTransactionsConfig(testResource string) string {
 
 func getWebTransactions(id string) (interface{}, error) {
 	api := (*tests.WebTransactionTestsAPIService)(&testClient.Common)
-	req := api.GetWebTransactionsTest(id).Expand(tests.AllowedExpandTestOptionsEnumValues)
+	req := api.GetWebTransactionsTest(id).Expand(knownExpandTestOptions())
 	req = SetAidFromContext(testClient.GetConfig().Context, req)
 	resp, _, err := req.Execute()
 	return resp, err

--- a/thousandeyes/schemas/dashboard_widget_schema.go
+++ b/thousandeyes/schemas/dashboard_widget_schema.go
@@ -19,9 +19,7 @@ var DashboardWidgetSchema = DashboardWidgetSchemaType{
 			"Time Series: Stacked Area",
 			"Pie Chart",
 			"Box and Whiskers",
-			// "List" is temporarily disabled until the API returns valid
-			// sortDirection values (CP-2702). The SDK cannot deserialize the
-			// ASC/DESC values the API currently sends, breaking refresh.
+			"List",
 			"Number",
 		}, false),
 	},


### PR DESCRIPTION
## Summary

Adds support for **List** dashboard widgets on the `thousandeyes_dashboard` resource: you can define List widgets in configuration together with other widget types, including optional `list_config` (for example, how far back to consider items as active).

Documentation and the dashboard example were updated to show a List widget. The ThousandEyes Go SDK dependency was upgraded so the provider stays aligned with the API for this widget type.

## Testing

- `go build ./...`
- Targeted package tests for List widget build/mapping and related helpers (run from the repository root with a supported Go version as declared in `go.mod`).

Dashboard acceptance tests need valid ThousandEyes credentials and environment variables as described in the provider README.