### PR TITLE
fix: preserve BGP measurement fields in state to prevent API drift

### DIFF
--- a/thousandeyes/schemas/alert_rule_schema.go
+++ b/thousandeyes/schemas/alert_rule_schema.go
@@ -151,6 +151,7 @@ var AlertRuleSchema = map[string]*schema.Schema{
 		Type:        schema.TypeString,
 		Required:    false,
 		Optional:    true,
+		Computed:    true,
 		ValidateFunc: validation.StringInSlice([]string{
 			"high",
 			"medium",

--- a/thousandeyes/schemas/common_schema.go
+++ b/thousandeyes/schemas/common_schema.go
@@ -654,7 +654,7 @@ var CommonSchema = map[string]*schema.Schema{
 		Type:        schema.TypeBool,
 		Description: "Set to 'true' to capture response headers for objects loaded by the test.",
 		Optional:    true,
-		Default:     true,
+		Computed:    true,
 	},
 	// oAuth
 	"oauth": oauth,

--- a/thousandeyes/schemas/common_schema.go
+++ b/thousandeyes/schemas/common_schema.go
@@ -172,6 +172,7 @@ var CommonSchema = map[string]*schema.Schema{
 		Type:        schema.TypeBool,
 		Description: "Enable to automatically add all available Public BGP Monitors to the test.",
 		Optional:    true,
+		Computed:    true,
 	},
 	// monitors (ex. bgp_monitors)
 	"monitors": {
@@ -211,7 +212,7 @@ var CommonSchema = map[string]*schema.Schema{
 		Type:         schema.TypeInt,
 		Description:  "The number of path traces.",
 		Optional:     true,
-		Required:     false,
+		Computed:     true,
 		ValidateFunc: validation.IntBetween(1, 10),
 	},
 	// pathTraceMode
@@ -250,7 +251,7 @@ var CommonSchema = map[string]*schema.Schema{
 		Type:        schema.TypeBool,
 		Description: "Enable BGP measurements. Set to true for enabled, false for disabled.",
 		Optional:    true,
-		Required:    false,
+		Computed:    true,
 	},
 
 	// AGENT TO AGENT
@@ -336,7 +337,7 @@ var CommonSchema = map[string]*schema.Schema{
 		Type:        schema.TypeBool,
 		Description: "Measure MTU sizes on the network from agents to the target.",
 		Optional:    true,
-		Required:    false,
+		Computed:    true,
 	},
 	// probeMode
 	"probe_mode": {

--- a/thousandeyes/schemas/legacy_schema.go
+++ b/thousandeyes/schemas/legacy_schema.go
@@ -143,18 +143,6 @@ func LegacyTestStateUpgrade(ctx context.Context, rawState map[string]any, meta a
 			rawState["custom_headers"] = nil
 		}
 
-		// These fields may be populated by API side effects in legacy state even
-		// when they were not explicitly configured. Drop them during upgrade so
-		// the read path can continue treating them as unset.
-		for _, field := range []string{
-			"bgp_measurements",
-			"use_public_bgp",
-			"mtu_measurements",
-			"num_path_traces",
-		} {
-			delete(rawState, field)
-		}
-
 		for _, field := range []string{"use_active_ftp", "use_explicit_ftps"} {
 			if value, ok := rawState[field]; ok {
 				rawState[field] = legacyStateBool(value)

--- a/thousandeyes/schemas/legacy_schema_test.go
+++ b/thousandeyes/schemas/legacy_schema_test.go
@@ -1,0 +1,75 @@
+package schemas
+
+import (
+	"context"
+	"testing"
+)
+
+func TestLegacyTestStateUpgradePreservesBgpFields(t *testing.T) {
+	rawState := map[string]any{
+		"test_name":          "My HTTP Server Test",
+		"interval":           300,
+		"url":                "https://example.com",
+		"bgp_measurements":   false,
+		"use_public_bgp":     false,
+		"mtu_measurements":   true,
+		"num_path_traces":    3,
+		"agents": []interface{}{
+			map[string]interface{}{
+				"agent_id":   1185,
+				"agent_name": "São Paulo, Brazil",
+			},
+		},
+	}
+
+	result, err := LegacyTestStateUpgrade(context.Background(), rawState, nil)
+	if err != nil {
+		t.Fatalf("LegacyTestStateUpgrade returned error: %v", err)
+	}
+
+	checks := []struct {
+		field    string
+		expected any
+	}{
+		{"bgp_measurements", false},
+		{"use_public_bgp", false},
+		{"mtu_measurements", true},
+		{"num_path_traces", 3},
+	}
+
+	for _, c := range checks {
+		val, ok := result[c.field]
+		if !ok {
+			t.Errorf("field %q was deleted during state upgrade; it should be preserved", c.field)
+			continue
+		}
+		if val != c.expected {
+			t.Errorf("field %q = %v, want %v", c.field, val, c.expected)
+		}
+	}
+}
+
+func TestLegacyTestStateUpgradeWorksWithoutBgpFields(t *testing.T) {
+	rawState := map[string]any{
+		"test_name": "Minimal Test",
+		"interval":  300,
+		"url":       "https://example.com",
+		"agents": []interface{}{
+			map[string]interface{}{
+				"agent_id":   1185,
+				"agent_name": "São Paulo, Brazil",
+			},
+		},
+	}
+
+	result, err := LegacyTestStateUpgrade(context.Background(), rawState, nil)
+	if err != nil {
+		t.Fatalf("LegacyTestStateUpgrade returned error: %v", err)
+	}
+
+	for _, field := range []string{"bgp_measurements", "use_public_bgp", "mtu_measurements", "num_path_traces"} {
+		if _, ok := result[field]; ok {
+			t.Errorf("field %q should not appear in state when it was not present in v2 state", field)
+		}
+	}
+}

--- a/thousandeyes/util.go
+++ b/thousandeyes/util.go
@@ -339,34 +339,6 @@ func FixReadValues(ctx context.Context, targetMaps map[string]map[string]interfa
 			return nil, nil
 		}
 
-	// Ignore BGP measurements if it wasn't set, prevents API side effects from being saved to state
-	case "bgp_measurements":
-		if isSet, _ := ctx.Value(setInConfigKey).(bool); !isSet {
-			*name = ""
-			return nil, nil
-		}
-
-	// Ignore use public bgp if it wasn't set, prevents API side effects (bgp_measurements) from being saved to state
-	case "use_public_bgp":
-		if isSet, _ := ctx.Value(setInConfigKey).(bool); !isSet {
-			*name = ""
-			return nil, nil
-		}
-
-	// Ignore MTU measurements if it wasn't set, prevents API side effects (network_measurements) from being saved to state
-	case "mtu_measurements":
-		if isSet, _ := ctx.Value(setInConfigKey).(bool); !isSet {
-			*name = ""
-			return nil, nil
-		}
-
-	// Ignore num path traces if it wasn't set, prevents API side effects (network_measurements) from being saved to state
-	case "num_path_traces":
-		if isSet, _ := ctx.Value(setInConfigKey).(bool); !isSet {
-			*name = ""
-			return nil, nil
-		}
-
 	// Normalize header order so API reordering does not cause drift.
 	case "headers":
 		if headers, ok := normalizeStringInterfaceSlice(m); ok {

--- a/thousandeyes/util_test.go
+++ b/thousandeyes/util_test.go
@@ -928,6 +928,130 @@ func TestFillValueEmptyStringToNilIntegration(t *testing.T) {
 	}
 }
 
+func TestFixReadValuesBgpFieldsAlwaysPassthrough(t *testing.T) {
+	fields := []struct {
+		name  string
+		value interface{}
+	}{
+		{"bgp_measurements", getPointer(false)},
+		{"bgp_measurements", getPointer(true)},
+		{"use_public_bgp", getPointer(true)},
+		{"use_public_bgp", getPointer(false)},
+		{"mtu_measurements", getPointer(true)},
+		{"mtu_measurements", getPointer(false)},
+		{"num_path_traces", getPointer("3")},
+	}
+
+	for _, tc := range fields {
+		t.Run(tc.name, func(t *testing.T) {
+			fieldName := tc.name
+
+			// Without setInConfigKey (field NOT in HCL) — should still pass through.
+			out, err := FixReadValues(context.Background(), nil, tc.value, &fieldName)
+			if err != nil {
+				t.Fatalf("FixReadValues(%q) returned error: %v", tc.name, err)
+			}
+			if fieldName == "" {
+				t.Fatalf("FixReadValues(%q) cleared the field name; value would be lost from state", tc.name)
+			}
+			if out == nil {
+				t.Fatalf("FixReadValues(%q) returned nil; value would be lost from state", tc.name)
+			}
+
+			// With setInConfigKey (field IS in HCL) — should also pass through.
+			fieldName2 := tc.name
+			ctx := context.WithValue(context.Background(), setInConfigKey, true)
+			out2, err2 := FixReadValues(ctx, nil, tc.value, &fieldName2)
+			if err2 != nil {
+				t.Fatalf("FixReadValues(%q, setInConfig) returned error: %v", tc.name, err2)
+			}
+			if fieldName2 == "" {
+				t.Fatalf("FixReadValues(%q, setInConfig) cleared the field name", tc.name)
+			}
+			if out2 == nil {
+				t.Fatalf("FixReadValues(%q, setInConfig) returned nil", tc.name)
+			}
+		})
+	}
+}
+
+func TestResourceReadBgpFieldsStoredInState(t *testing.T) {
+	d := getReferenceData(resourceHTTPServer().Schema, map[string]string{})
+
+	bgp := false
+	publicBgp := false
+	mtu := true
+	numPaths := int32(3)
+	network := true
+
+	remoteResource := tests.NewHttpServerTestResponse(tests.TESTINTERVAL__300, "https://example.com")
+	remoteResource.BgpMeasurements = &bgp
+	remoteResource.UsePublicBgp = &publicBgp
+	remoteResource.MtuMeasurements = &mtu
+	remoteResource.NumPathTraces = &numPaths
+	remoteResource.NetworkMeasurements = &network
+
+	if err := ResourceRead(context.TODO(), d, remoteResource); err != nil {
+		t.Fatalf("ResourceRead returned error: %v", err)
+	}
+
+	checks := []struct {
+		field    string
+		expected interface{}
+	}{
+		{"bgp_measurements", false},
+		{"use_public_bgp", false},
+		{"mtu_measurements", true},
+		{"num_path_traces", 3},
+		{"network_measurements", true},
+	}
+
+	for _, c := range checks {
+		got := d.Get(c.field)
+		if got != c.expected {
+			t.Errorf("state[%q] = %v (%T), want %v (%T)", c.field, got, got, c.expected, c.expected)
+		}
+	}
+}
+
+func TestResourceBuildStructBgpFieldsIncludedInRequest(t *testing.T) {
+	attrs := map[string]string{
+		"bgp_measurements":     "false",
+		"use_public_bgp":       "false",
+		"mtu_measurements":     "true",
+		"num_path_traces":      "3",
+		"network_measurements": "true",
+	}
+	d := getReferenceData(schemas.CommonSchema, attrs)
+	req := tests.HttpServerTestRequest{}
+	ResourceBuildStruct(d, &req)
+
+	if req.BgpMeasurements == nil {
+		t.Fatal("BgpMeasurements nil in request struct; would be omitted from API payload")
+	}
+	if *req.BgpMeasurements != false {
+		t.Errorf("BgpMeasurements = %v, want false", *req.BgpMeasurements)
+	}
+
+	if req.UsePublicBgp == nil {
+		t.Fatal("UsePublicBgp nil in request struct; would be omitted from API payload")
+	}
+
+	if req.MtuMeasurements == nil {
+		t.Fatal("MtuMeasurements nil in request struct; would be omitted from API payload")
+	}
+	if *req.MtuMeasurements != true {
+		t.Errorf("MtuMeasurements = %v, want true", *req.MtuMeasurements)
+	}
+
+	if req.NumPathTraces == nil {
+		t.Fatal("NumPathTraces nil in request struct; would be omitted from API payload")
+	}
+	if *req.NumPathTraces != 3 {
+		t.Errorf("NumPathTraces = %v, want 3", *req.NumPathTraces)
+	}
+}
+
 func TestFixReadValuesTagBuiltInSupported(t *testing.T) {
 	ctx := context.WithValue(context.Background(), tagsKey, struct{}{})
 	name := "built_in"


### PR DESCRIPTION
## Problem

Several schema fields used `Optional` without `Computed`, causing state drift when values weren't explicitly configured in HCL. The provider's `FixReadValues` skip logic (#306) and `LegacyTestStateUpgrade` field deletion (#295) made this worse by actively suppressing API-returned values from state.

**BGP/network fields**: `bgp_measurements`, `use_public_bgp`, `mtu_measurements`, `num_path_traces` were absent from state, so the SDK's `omitempty` omitted them from API payloads, and the v7 API applied its own defaults — silently flipping `bgpMeasurements` from `false` to `true`.

**`sensitivity_level`** (alert rules): `Optional`-only, causing Terraform to null it out (`"medium" -> null`) when not in HCL — a destructive change to alert behavior.

**`include_headers`** (http_server): Used `Default: true` instead of `Computed: true`, forcing a spurious plan diff on v2→v3 migration since the field wasn't in state.

## Fix

Use the [Terraform-recommended](https://developer.hashicorp.com/terraform/plugin/sdkv2/best-practices/detecting-drift) `Optional + Computed` pattern: the user may set these fields, but if they don't, the provider accepts and preserves whatever the API returns. This keeps the Read→Build round-trip intact and prevents the `omitempty` gap.

- Add `Computed: true` to `bgp_measurements`, `use_public_bgp`, `mtu_measurements`, `num_path_traces`, `sensitivity_level`, `include_headers`
- Change `include_headers` from `Default: true` to `Computed: true`
- Remove the `FixReadValues` cases that suppressed BGP fields
- Remove the `LegacyTestStateUpgrade` loop that deleted BGP fields during v2→v3 migration

## Test plan

### Unit tests

Covering `FixReadValues` passthrough, `ResourceRead` state storage, `ResourceBuildStruct` payload inclusion, and `LegacyTestStateUpgrade` field preservation.

### Manual tests (staging)

**v3 new test** — create with fixed provider, no flags configured, verify state + API + no drift

**v2 → v3** — create with v2 provider, upgrade to fixed v3, verify `bgp_measurements=false` preserved in state and API

**v2 → v3.2.0 (broken) → fixed v3** — reproduce the real-world damage:
1. v2 creates test (`bgpMeasurements=false` on API)
2. v3.2.0 wipes state, API flips to `true` (demonstrates the bug)
3. Fixed provider recovers state from API (`true` — damage is permanent)
4. User remediation: explicitly set `bgp_measurements=false` in HCL → API restored to `false`

**Flag combinations** — single test mutated through 5 combos, asserting state + API + no drift after each:

| Combo | Config | bgp | public | mtu | traces | network |
|-------|--------|-----|--------|-----|--------|---------|
| 1 | No flags (fixup defaults) | false | false | true | 3 | true |
| 2 | bgp=true, public=true | true | true | true | 3 | true |
| 3 | bgp=false, public=false | false | false | true | 3 | true |
| 4 | bgp=false, mtu=false | false | false | false | 3 | true |
| 5 | All explicit, traces=10 | true | true | true | 10 | true |