### PR TITLE
fix: Make dashboard widget `direction` read-only

### DIFF
--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -246,7 +246,6 @@ Optional:
 - `agent_status_config` (Block List, Max: 1) Configuration for Agent Status widgets. (see [below for nested schema](#nestedblock--widgets--agent_status_config))
 - `box_and_whiskers_config` (Block List, Max: 1) Configuration for Box and Whiskers widgets. (see [below for nested schema](#nestedblock--widgets--box_and_whiskers_config))
 - `data_source` (String) Data source for the widget.
-- `direction` (String) Direction for the metric (e.g., 'To Target', 'From Target', 'Bidirectional').
 - `filter` (Block List) Filters applied to the widget. Each filter specifies a property and list of values. (see [below for nested schema](#nestedblock--widgets--filter))
 - `fixed_timespan` (Block List, Max: 1) Fixed timespan for the widget. (see [below for nested schema](#nestedblock--widgets--fixed_timespan))
 - `geo_map_config` (Block List, Max: 1) Configuration for Map widgets. (see [below for nested schema](#nestedblock--widgets--geo_map_config))
@@ -264,6 +263,7 @@ Optional:
 
 Read-Only:
 
+- `direction` (String) Direction for the metric (e.g., 'To Target', 'From Target', 'Bidirectional').
 - `embed_url` (String) When isEmbedded is set to true, an embedUrl is provided.
 - `id` (String) Identifier of the widget.
 - `is_embedded` (Boolean) Indicates whether the widget is marked as embedded.

--- a/thousandeyes/acceptance_resources/dashboard/widget_list_defaults.tf
+++ b/thousandeyes/acceptance_resources/dashboard/widget_list_defaults.tf
@@ -9,7 +9,6 @@ resource "thousandeyes_dashboard" "test_dashboard_list_defaults" {
     type        = "List"
     title       = "List With Defaults"
     data_source = "EVENT_DETECTION"
-    direction   = "TO_TARGET"
     measure {
       type = "MEAN"
     }

--- a/thousandeyes/schemas/dashboard_widget_schema.go
+++ b/thousandeyes/schemas/dashboard_widget_schema.go
@@ -63,7 +63,6 @@ var DashboardWidgetSchema = DashboardWidgetSchemaType{
 	"direction": {
 		Type:        schema.TypeString,
 		Description: "Direction for the metric (e.g., 'To Target', 'From Target', 'Bidirectional').",
-		Optional:    true,
 		Computed:    true,
 	},
 	"metric": {

--- a/thousandeyes/widget_builders.go
+++ b/thousandeyes/widget_builders.go
@@ -333,13 +333,7 @@ func setCommonBuilderFields(widget interface{}, data map[string]interface{}) {
 			w.SetMetricGroup(dashboards.MetricGroup(metricGroup))
 		}
 	}
-	if direction := getStringValue(data, "direction"); direction != "" {
-		if w, ok := widget.(interface {
-			SetDirection(dashboards.DashboardMetricDirection)
-		}); ok {
-			w.SetDirection(dashboards.DashboardMetricDirection(direction))
-		}
-	}
+	// direction is read-only in the API; it is populated on refresh from the metric.
 	if metric := getStringValue(data, "metric"); metric != "" {
 		if w, ok := widget.(interface {
 			SetMetric(dashboards.DashboardMetric)

--- a/thousandeyes/widget_builders.go
+++ b/thousandeyes/widget_builders.go
@@ -333,7 +333,6 @@ func setCommonBuilderFields(widget interface{}, data map[string]interface{}) {
 			w.SetMetricGroup(dashboards.MetricGroup(metricGroup))
 		}
 	}
-	// direction is read-only in the API; it is populated on refresh from the metric.
 	if metric := getStringValue(data, "metric"); metric != "" {
 		if w, ok := widget.(interface {
 			SetMetric(dashboards.DashboardMetric)


### PR DESCRIPTION
## Summary

Dashboard widgets expose a `direction` attribute (e.g. traffic direction for metrics). The ThousandEyes API **does not accept** `direction` as an independent input on create or update—it is **derived from the widget’s metric**. Continuing to send `direction` from Terraform could cause unnecessary drift or imply a capability the API does not provide.

This change aligns the provider with the API: `direction` is **computed-only** (read from state after apply/refresh) and is **no longer written** in widget builder payloads.

## What changed

- **Schema** (`dashboard_widget_schema.go`): `direction` is `Computed` only (removed `Optional`). The field description is unchanged from before this work.
- **Builders** (`widget_builders.go`): Stop calling `SetDirection` when building widgets for create/update.
- **Docs** (`docs/resources/dashboard.md`): Regenerated so `direction` appears under **Read-Only**.
- **Acceptance fixtures**: Removed `direction = "TO_TARGET"` from List widget examples, since that argument is no longer valid in configuration.

## Breaking change

**Any existing configuration that sets `direction` inside a `thousandeyes_dashboard` widget block must remove that argument.** Terraform will report it as an unsupported/unknown argument.

Users who need a specific direction should choose a **metric** whose id encodes the desired direction (as they would in the product UI/API), not a separate `direction` field.

## How tested

- `mise exec go@1.24 -- go test ./...` in `terraform-provider-thousandeyes`
- `mise exec go@1.24 -- go generate ./...` to refresh provider docs