### PR TITLE
AI-8200: Remove 'transactions' alert type

### DIFF
--- a/thousandeyes/schemas/alert_rule_schema.go
+++ b/thousandeyes/schemas/alert_rule_schema.go
@@ -70,7 +70,6 @@ var AlertRuleSchema = map[string]*schema.Schema{
 			"path-trace",
 			"ftp",
 			"sip-server",
-			"transactions",
 			"web-transactions",
 			"agent",
 			"network-outage",


### PR DESCRIPTION
This alert type is not supported by the backend any longer

Any requests with `alert_type=transactions` face 500 HTTP code and having this value in the schema only causes unnecessary confusion.