### PR TITLE
feature: Remove unsupported column-level filter and direction from Multi Metric Table

### DIFF
--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -374,8 +374,6 @@ Optional:
 Optional:
 
 - `data_source` (String) Data source for the column.
-- `direction` (String) Direction for the metric (e.g., TO_TARGET, FROM_TARGET). Only applicable to certain data sources.
-- `filter` (Block Set) Filters applied to the column. Order is not significant. (see [below for nested schema](#nestedblock--widgets--multi_metric_columns--filter))
 - `measure` (Block List, Max: 1) Measure configuration for the column. (see [below for nested schema](#nestedblock--widgets--multi_metric_columns--measure))
 - `metric` (String) Metric for the column.
 - `metric_group` (String) Metric group for the column.
@@ -383,15 +381,6 @@ Optional:
 Read-Only:
 
 - `id` (String) Identifier of the column.
-
-<a id="nestedblock--widgets--multi_metric_columns--filter"></a>
-### Nested Schema for `widgets.multi_metric_columns.filter`
-
-Required:
-
-- `property` (String) Filter property.
-- `values` (Set of String) Set of filter values (IDs). Order is not significant.
-
 
 <a id="nestedblock--widgets--multi_metric_columns--measure"></a>
 ### Nested Schema for `widgets.multi_metric_columns.measure`

--- a/thousandeyes/schemas/dashboard_widget_schema.go
+++ b/thousandeyes/schemas/dashboard_widget_schema.go
@@ -547,12 +547,6 @@ var MultiMetricColumnSchema = map[string]*schema.Schema{
 		Description: "Metric group for the column.",
 		Optional:    true,
 	},
-	"direction": {
-		Type:        schema.TypeString,
-		Description: "Direction for the metric (e.g., TO_TARGET, FROM_TARGET). Only applicable to certain data sources.",
-		Optional:    true,
-		Computed:    true,
-	},
 	"metric": {
 		Type:        schema.TypeString,
 		Description: "Metric for the column.",
@@ -574,26 +568,6 @@ var MultiMetricColumnSchema = map[string]*schema.Schema{
 					Type:        schema.TypeFloat,
 					Description: "Percentile value when type is NTH_PERCENTILE.",
 					Optional:    true,
-				},
-			},
-		},
-	},
-	"filter": {
-		Type:        schema.TypeSet,
-		Description: "Filters applied to the column. Order is not significant.",
-		Optional:    true,
-		Elem: &schema.Resource{
-			Schema: map[string]*schema.Schema{
-				"property": {
-					Type:        schema.TypeString,
-					Description: "Filter property.",
-					Required:    true,
-				},
-				"values": {
-					Type:        schema.TypeSet,
-					Description: "Set of filter values (IDs). Order is not significant.",
-					Required:    true,
-					Elem:        &schema.Schema{Type: schema.TypeString},
 				},
 			},
 		},

--- a/thousandeyes/widget_builders.go
+++ b/thousandeyes/widget_builders.go
@@ -356,9 +356,6 @@ func buildMultiMetricColumns(columnsList []interface{}) []dashboards.ApiMultiMet
 		if v := getStringValue(colData, "metric_group"); v != "" {
 			col.SetMetricGroup(dashboards.MetricGroup(v))
 		}
-		if v := getStringValue(colData, "direction"); v != "" {
-			col.SetDirection(dashboards.DashboardMetricDirection(v))
-		}
 		if v := getStringValue(colData, "metric"); v != "" {
 			col.SetMetric(dashboards.DashboardMetric(v))
 		}
@@ -373,38 +370,6 @@ func buildMultiMetricColumns(columnsList []interface{}) []dashboards.ApiMultiMet
 				m.SetPercentileValue(float32(v))
 			}
 			col.SetMeasure(*m)
-		}
-
-		if filterList := getSetValue(colData, "filter"); len(filterList) > 0 {
-			apiFilters := make(map[string][]interface{})
-			for _, f := range filterList {
-				filterData := f.(map[string]interface{})
-				property := getStringValue(filterData, "property")
-				if property == "" {
-					continue
-				}
-				var values []interface{}
-				switch v := filterData["values"].(type) {
-				case *schema.Set:
-					strs := make([]string, 0, v.Len())
-					for _, item := range v.List() {
-						strs = append(strs, item.(string))
-					}
-					sort.Strings(strs)
-					values = make([]interface{}, len(strs))
-					for i, s := range strs {
-						values[i] = s
-					}
-				case []interface{}:
-					values = v
-				}
-				if len(values) > 0 {
-					apiFilters[property] = values
-				}
-			}
-			if len(apiFilters) > 0 {
-				col.SetFilters(apiFilters)
-			}
 		}
 
 		columns = append(columns, *col)

--- a/thousandeyes/widget_mappers.go
+++ b/thousandeyes/widget_mappers.go
@@ -409,9 +409,6 @@ func mapMultiMetricColumns(columns []dashboards.ApiMultiMetricColumn) []interfac
 		if v := col.GetMetricGroup(); v != "" {
 			colData["metric_group"] = string(v)
 		}
-		if v := col.GetDirection(); v != "" {
-			colData["direction"] = string(v)
-		}
 		if v := col.GetMetric(); v != "" {
 			colData["metric"] = string(v)
 		}
@@ -427,10 +424,6 @@ func mapMultiMetricColumns(columns []dashboards.ApiMultiMetricColumn) []interfac
 			if len(measureMap) > 0 {
 				colData["measure"] = []interface{}{measureMap}
 			}
-		}
-
-		if filters, ok := col.GetFiltersOk(); ok && filters != nil && len(*filters) > 0 {
-			colData["filter"] = mapFilterBlocks(*filters)
 		}
 
 		result = append(result, colData)

--- a/thousandeyes/widget_multi_metric_table_test.go
+++ b/thousandeyes/widget_multi_metric_table_test.go
@@ -89,33 +89,6 @@ func TestBuildMultiMetricTableWidget(t *testing.T) {
 			},
 		},
 		{
-			name: "column with filters",
-			input: map[string]interface{}{
-				"type":  "Multi Metric Table",
-				"title": "Filtered Table",
-				"multi_metric_columns": []interface{}{
-					map[string]interface{}{
-						"data_source":  "ALERTS",
-						"metric_group": "ALERTS",
-						"metric":       "ALERT_COUNT_AGENT",
-						"filter": testFilterSet(map[string]interface{}{
-							"property": "TEST",
-							"values":   []interface{}{"12345"},
-						}),
-					},
-				},
-			},
-			validate: func(t *testing.T, widget dashboards.ApiWidget) {
-				w := widget.ApiMultiMetricTableWidget
-				assert.NotNil(t, w)
-				cols := w.GetMultiMetricColumns()
-				assert.Len(t, cols, 1)
-				filters := cols[0].GetFilters()
-				assert.Contains(t, filters, "TEST")
-				assert.Equal(t, []interface{}{"12345"}, filters["TEST"])
-			},
-		},
-		{
 			name: "column with percentile measure",
 			input: map[string]interface{}{
 				"type":  "Multi Metric Table",
@@ -245,30 +218,6 @@ func TestMapMultiMetricTableWidget(t *testing.T) {
 				col2 := cols[1].(map[string]interface{})
 				assert.Equal(t, "col-2", col2["id"])
 				assert.Equal(t, "ACTIVE_ALERT_COUNT", col2["metric"])
-			},
-		},
-		{
-			name: "column with filters",
-			input: func() dashboards.ApiWidget {
-				w := dashboards.NewApiMultiMetricTableWidget("Multi Metric Table")
-				w.SetTitle("Filtered Table")
-				col := dashboards.NewApiMultiMetricColumn()
-				col.SetId("col-f")
-				col.SetFilters(map[string][]interface{}{
-					"TEST": {"12345"},
-				})
-				w.SetMultiMetricColumns([]dashboards.ApiMultiMetricColumn{*col})
-				return dashboards.ApiMultiMetricTableWidgetAsApiWidget(w)
-			},
-			validate: func(t *testing.T, data map[string]interface{}) {
-				cols := data["multi_metric_columns"].([]interface{})
-				assert.Len(t, cols, 1)
-				col := cols[0].(map[string]interface{})
-				filters := col["filter"].([]interface{})
-				assert.Len(t, filters, 1)
-				f := filters[0].(map[string]interface{})
-				assert.Equal(t, "TEST", f["property"])
-				assert.Equal(t, []interface{}{"12345"}, f["values"])
 			},
 		},
 		{


### PR DESCRIPTION
## Summary
- Removed `filter` and `direction` from `MultiMetricColumnSchema` — confirmed these are widget-level properties only and are not persisted on `ApiMultiMetricColumn`
- Cleaned up corresponding builder, mapper, and unit test code
- Prevents state drift caused by the provider sending fields the API silently discards

## Test plan
- [x] `go build ./...` passes
- [x] All unit tests pass (`go test ./thousandeyes/`)
- [x] `go generate` docs updated
- [x] Acceptance tests pass in CI