### PR TITLE
feature: Restore direction field for Multi Metric Table columns

### DIFF
--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -417,6 +417,7 @@ Optional:
 Optional:
 
 - `data_source` (String) Data source for the column.
+- `direction` (String) Direction for the metric (e.g., TO_TARGET, FROM_TARGET). Only applicable to certain data sources.
 - `measure` (Block List, Max: 1) Measure configuration for the column. (see [below for nested schema](#nestedblock--widgets--multi_metric_columns--measure))
 - `metric` (String) Metric for the column.
 - `metric_group` (String) Metric group for the column.

--- a/thousandeyes/schemas/dashboard_widget_schema.go
+++ b/thousandeyes/schemas/dashboard_widget_schema.go
@@ -840,6 +840,12 @@ var MultiMetricColumnSchema = map[string]*schema.Schema{
 		Description: "Metric group for the column.",
 		Optional:    true,
 	},
+	"direction": {
+		Type:        schema.TypeString,
+		Description: "Direction for the metric (e.g., TO_TARGET, FROM_TARGET). Only applicable to certain data sources.",
+		Optional:    true,
+		Computed:    true,
+	},
 	"metric": {
 		Type:        schema.TypeString,
 		Description: "Metric for the column.",

--- a/thousandeyes/widget_builders.go
+++ b/thousandeyes/widget_builders.go
@@ -523,6 +523,9 @@ func buildMultiMetricColumns(columnsList []interface{}) []dashboards.ApiMultiMet
 		if v := getStringValue(colData, "metric_group"); v != "" {
 			col.SetMetricGroup(dashboards.MetricGroup(v))
 		}
+		if v := getStringValue(colData, "direction"); v != "" {
+			col.SetDirection(dashboards.DashboardMetricDirection(v))
+		}
 		if v := getStringValue(colData, "metric"); v != "" {
 			col.SetMetric(dashboards.DashboardMetric(v))
 		}

--- a/thousandeyes/widget_mappers.go
+++ b/thousandeyes/widget_mappers.go
@@ -645,6 +645,9 @@ func mapMultiMetricColumns(columns []dashboards.ApiMultiMetricColumn) []interfac
 		if v := col.GetMetricGroup(); v != "" {
 			colData["metric_group"] = string(v)
 		}
+		if v := col.GetDirection(); v != "" {
+			colData["direction"] = string(v)
+		}
 		if v := col.GetMetric(); v != "" {
 			colData["metric"] = string(v)
 		}

--- a/thousandeyes/widget_multi_metric_table_test.go
+++ b/thousandeyes/widget_multi_metric_table_test.go
@@ -118,6 +118,34 @@ func TestBuildMultiMetricTableWidget(t *testing.T) {
 			},
 		},
 		{
+			name: "column with direction",
+			input: map[string]interface{}{
+				"type":  "Multi Metric Table",
+				"title": "Table With Direction",
+				"multi_metric_columns": []interface{}{
+					map[string]interface{}{
+						"data_source":  "CLOUD_AND_ENTERPRISE_AGENTS",
+						"metric_group": "AGENT_TO_AGENT",
+						"direction":    "TO_TARGET",
+						"metric":       "NET_LATENCY",
+						"measure": []interface{}{
+							map[string]interface{}{
+								"type": "MEAN",
+							},
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, widget dashboards.ApiWidget) {
+				w := widget.ApiMultiMetricTableWidget
+				assert.NotNil(t, w)
+				cols := w.GetMultiMetricColumns()
+				assert.Len(t, cols, 1)
+				assert.Equal(t, dashboards.DashboardMetricDirection("TO_TARGET"), cols[0].GetDirection())
+				assert.Equal(t, dashboards.DashboardMetric("NET_LATENCY"), cols[0].GetMetric())
+			},
+		},
+		{
 			name: "removing all columns sends empty array",
 			input: map[string]interface{}{
 				"type":  "Multi Metric Table",
@@ -218,6 +246,27 @@ func TestMapMultiMetricTableWidget(t *testing.T) {
 				col2 := cols[1].(map[string]interface{})
 				assert.Equal(t, "col-2", col2["id"])
 				assert.Equal(t, "ACTIVE_ALERT_COUNT", col2["metric"])
+			},
+		},
+		{
+			name: "column with direction",
+			input: func() dashboards.ApiWidget {
+				w := dashboards.NewApiMultiMetricTableWidget("Multi Metric Table")
+				w.SetTitle("Direction Table")
+				col := dashboards.NewApiMultiMetricColumn()
+				col.SetId("col-d")
+				col.SetDataSource(dashboards.MultiMetricsTableDatasource("CLOUD_AND_ENTERPRISE_AGENTS"))
+				col.SetMetricGroup(dashboards.MetricGroup("AGENT_TO_AGENT"))
+				col.SetDirection(dashboards.DashboardMetricDirection("TO_TARGET"))
+				col.SetMetric(dashboards.DashboardMetric("NET_LATENCY"))
+				w.SetMultiMetricColumns([]dashboards.ApiMultiMetricColumn{*col})
+				return dashboards.ApiMultiMetricTableWidgetAsApiWidget(w)
+			},
+			validate: func(t *testing.T, data map[string]interface{}) {
+				cols := data["multi_metric_columns"].([]interface{})
+				col := cols[0].(map[string]interface{})
+				assert.Equal(t, "TO_TARGET", col["direction"])
+				assert.Equal(t, "NET_LATENCY", col["metric"])
 			},
 		},
 		{


### PR DESCRIPTION
## Summary
- Restores `direction` field to `MultiMetricColumnSchema` with `Optional: true, Computed: true`
- Adds direction handling in builder and mapper for MMT columns
- Adds unit tests for column-level direction (builder and mapper)
- `direction` is supported at the column level for certain data sources (e.g., Agent-to-Agent) and was incorrectly removed in PR #319

<img width="476" height="734" alt="image" src="https://github.com/user-attachments/assets/c0484f5d-de8c-43fa-9f3d-b0ea085065cb" />

## Test plan
- [x] Unit tests pass for builder and mapper with direction
- [x] Manual smoke test with Agent-to-Agent metric using `direction = "TO_TARGET"` on MMT column


Made with [Cursor](https://cursor.com)