### PR TITLE
fix: update sdk to alpha.18 and align dashboard/http server contracts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,11 @@ jobs:
           args: build --snapshot
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: '1.5.*'
+          terraform_wrapper: false
       - name: Run go generate
         run: go generate
       - name: Check differences after go generate

--- a/docs/resources/http_server.md
+++ b/docs/resources/http_server.md
@@ -164,16 +164,15 @@ Optional:
 
 Required:
 
-- `config_id` (String) The ID of the OAuth configuration.
 - `test_url` (String) Target for the test.
 
 Optional:
 
-- `auth_type` (String) [none, basic, ntlm, kerberos, oauth] The HTTP authentication type. Defaults to 'none'.
+- `auth_type` (String) [none, basic, ntlm] The HTTP authentication type. Defaults to 'none'.
 - `headers` (String, Sensitive) Request headers used for OAuth.
 - `password` (String, Sensitive) OAuth password
 - `post_body` (String) Enter the OAuth body for the HTTP POST request in this field when using OAuth as the authentication mechanism. No special escaping is required. If content is provided in the post body, the `requestMethod` is automatically set to POST.
-- `request_method` (String) [get, post, put, delete, patch, options, trace] Request method.
+- `request_method` (String) [get, post] Request method.
 - `username` (String) OAuth username
 
 ## Import

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/terraform-plugin-docs v0.21.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.36.1
 	github.com/stretchr/testify v1.8.4
-	github.com/thousandeyes/thousandeyes-sdk-go/v3 v3.0.0-alpha.16
+	github.com/thousandeyes/thousandeyes-sdk-go/v3 v3.0.0-alpha.18
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -193,8 +193,8 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/thousandeyes/thousandeyes-sdk-go/v3 v3.0.0-alpha.16 h1:trxLKxOWYQrya8gowL4pnYRSmdjHrdRkLUVf7XxaH9s=
-github.com/thousandeyes/thousandeyes-sdk-go/v3 v3.0.0-alpha.16/go.mod h1:EWD+kNN2rC06wBi+KB9dIOM+4WJin7VZjqcFSgHF+Ow=
+github.com/thousandeyes/thousandeyes-sdk-go/v3 v3.0.0-alpha.18 h1:ruCDKW7t+e9Sk1uqZLEiyeICPUVmycgNn9exYTiMOpE=
+github.com/thousandeyes/thousandeyes-sdk-go/v3 v3.0.0-alpha.18/go.mod h1:EWD+kNN2rC06wBi+KB9dIOM+4WJin7VZjqcFSgHF+Ow=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/thousandeyes/acceptance_resources/dashboard/widget_alert_list_defaults.tf
+++ b/thousandeyes/acceptance_resources/dashboard/widget_alert_list_defaults.tf
@@ -1,0 +1,23 @@
+resource "thousandeyes_dashboard" "test_dashboard_alert_list_defaults" {
+  description = "Test Dashboard with Alert List default alert types"
+  title       = "Test Dashboard Alert List Default Alert Types"
+  is_private  = false
+
+  default_timespan {
+    duration = 3600
+  }
+
+  widgets {
+    type        = "Alert List"
+    title       = "Alert List Default Alert Types"
+    visual_mode = "Full"
+    data_source = "ALERTS"
+
+    alert_list_config {
+      limit_to = 15
+
+      active_within_value = 7
+      active_within_unit  = "Days"
+    }
+  }
+}

--- a/thousandeyes/acceptance_resources/dashboard/widget_color_grid_defaults.tf
+++ b/thousandeyes/acceptance_resources/dashboard/widget_color_grid_defaults.tf
@@ -1,0 +1,35 @@
+resource "thousandeyes_dashboard" "test_dashboard_color_grid_defaults" {
+  description = "Test Dashboard with Color Grid default columns"
+  title       = "Test Dashboard Color Grid Default Columns"
+  is_private  = false
+
+  default_timespan {
+    duration = 3600
+  }
+
+  widgets {
+    type         = "Color Grid"
+    title        = "Color Grid Default Columns"
+    visual_mode  = "Full"
+    data_source  = "ALERTS"
+    metric_group = "ALERTS"
+    metric       = "ALERT_COUNT_AGENT"
+
+    measure {
+      type = "MEAN"
+    }
+
+    fixed_timespan {
+      value = 1
+      unit  = "Days"
+    }
+
+    color_grid_config {
+      min_scale      = 0
+      max_scale      = 100
+      cards          = "COUNTRY"
+      group_cards_by = "TEST"
+      limit          = 6
+    }
+  }
+}

--- a/thousandeyes/acceptance_resources/dashboard/widget_test_table_basic.tf
+++ b/thousandeyes/acceptance_resources/dashboard/widget_test_table_basic.tf
@@ -26,7 +26,7 @@ resource "thousandeyes_dashboard" "test_dashboard_test_table_widget" {
         type = "any"
 
         filters {
-          key   = "Test ID"
+          key   = "Tag ID"
           value = "123"
         }
       }

--- a/thousandeyes/acceptance_resources/dashboard/widget_test_table_tag_id_stable_plan.tf
+++ b/thousandeyes/acceptance_resources/dashboard/widget_test_table_tag_id_stable_plan.tf
@@ -1,0 +1,22 @@
+resource "thousandeyes_dashboard" "test_dashboard_test_table_tag_id_stable_plan" {
+  description = "Test Dashboard with Test Table Tag ID stable plan coverage"
+  title       = "Test Dashboard Test Table Tag ID Stable Plan"
+  is_private  = false
+
+  widgets {
+    type        = "Test Table"
+    title       = "Test Table Tag ID Stable Plan"
+    visual_mode = "Full"
+
+    test_table_config {
+      filter {
+        type = "all"
+
+        filters {
+          key   = "Tag ID"
+          value = "123"
+        }
+      }
+    }
+  }
+}

--- a/thousandeyes/acceptance_resources/dashboard/widget_test_table_update.tf
+++ b/thousandeyes/acceptance_resources/dashboard/widget_test_table_update.tf
@@ -26,7 +26,7 @@ resource "thousandeyes_dashboard" "test_dashboard_test_table_widget" {
         type = "all"
 
         filters {
-          key   = "Test ID"
+          key   = "Tag ID"
           value = "456"
         }
       }

--- a/thousandeyes/http_server_headers.go
+++ b/thousandeyes/http_server_headers.go
@@ -146,9 +146,6 @@ func terraformHTTPServerOAuthValue(oauth *tests.OAuth) []interface{} {
 	}
 
 	value := map[string]interface{}{}
-	if oauth.ConfigId != nil && *oauth.ConfigId != "" {
-		value["config_id"] = *oauth.ConfigId
-	}
 	if oauth.TestUrl != nil && *oauth.TestUrl != "" {
 		value["test_url"] = *oauth.TestUrl
 	}
@@ -161,7 +158,7 @@ func terraformHTTPServerOAuthValue(oauth *tests.OAuth) []interface{} {
 	if oauth.Headers != nil && *oauth.Headers != "" {
 		value["headers"] = *oauth.Headers
 	}
-	if oauth.AuthType != nil && *oauth.AuthType != "" && *oauth.AuthType != tests.TESTAUTHTYPE_NONE {
+	if oauth.AuthType != nil && string(*oauth.AuthType) != "" && string(*oauth.AuthType) != "none" {
 		value["auth_type"] = string(*oauth.AuthType)
 	}
 	if oauth.Username != nil && *oauth.Username != "" {

--- a/thousandeyes/http_server_headers_test.go
+++ b/thousandeyes/http_server_headers_test.go
@@ -72,36 +72,50 @@ func TestTerraformHTTPServerOAuthValue_zeroValueReturnsEmpty(t *testing.T) {
 }
 
 func TestTerraformHTTPServerOAuthValue_preservesConfiguredFields(t *testing.T) {
-	configID := "2660950"
 	testURL := "https://auth.example.com/oauth/token"
-	requestMethod := tests.REQUESTMETHOD_GET
 	header := "Authorization: Basic test-client"
 	username := "oauth-user"
-	authType := tests.TESTAUTHTYPE_BASIC
+	oauth := tests.NewOAuth()
+	oauth.TestUrl = &testURL
+	oauth.Headers = &header
+	oauth.Username = &username
+	setOAuthNamedStringField(t, oauth, "RequestMethod", "get")
+	setOAuthNamedStringField(t, oauth, "AuthType", "basic")
 
-	got := terraformHTTPServerOAuthValue(&tests.OAuth{
-		ConfigId:      &configID,
-		TestUrl:       &testURL,
-		RequestMethod: &requestMethod,
-		Headers:       &header,
-		Username:      &username,
-		AuthType:      &authType,
-	})
+	got := terraformHTTPServerOAuthValue(oauth)
 
 	want := []interface{}{
 		map[string]interface{}{
-			"config_id":      configID,
 			"test_url":       testURL,
-			"request_method": string(requestMethod),
+			"request_method": "get",
 			"headers":        header,
 			"username":       username,
-			"auth_type":      string(authType),
+			"auth_type":      "basic",
 		},
 	}
 
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("unexpected terraform oauth value: got %#v want %#v", got, want)
 	}
+}
+
+func setOAuthNamedStringField(t *testing.T, oauth *tests.OAuth, fieldName string, value string) {
+	t.Helper()
+
+	field := reflect.ValueOf(oauth).Elem().FieldByName(fieldName)
+	if !field.IsValid() {
+		t.Fatalf("oauth field %q does not exist", fieldName)
+	}
+	if field.Kind() != reflect.Pointer {
+		t.Fatalf("oauth field %q is not a pointer: %s", fieldName, field.Kind())
+	}
+	if field.Type().Elem().Kind() != reflect.String {
+		t.Fatalf("oauth field %q does not point to a string-like type: %s", fieldName, field.Type().Elem().Kind())
+	}
+
+	ptr := reflect.New(field.Type().Elem())
+	ptr.Elem().SetString(value)
+	field.Set(ptr)
 }
 
 func TestRawConfigCustomHeadersAllowsEmptyBlock(t *testing.T) {

--- a/thousandeyes/resource_agent_to_server.go
+++ b/thousandeyes/resource_agent_to_server.go
@@ -73,9 +73,9 @@ func resourceAgentServerUpdate(d *schema.ResourceData, m interface{}) error {
 	api := (*tests.AgentToServerTestsAPIService)(&apiClient.Common)
 
 	log.Printf("[INFO] Updating ThousandEyes Test %s", d.Id())
-	update := buildAgentServerStruct(d)
+	update := buildAgentServerUpdateStruct(d)
 
-	req := api.UpdateAgentToServerTest(d.Id()).AgentToServerTestRequest(*update).Expand(knownExpandTestOptions())
+	req := api.UpdateAgentToServerTest(d.Id()).UpdateAgentToServerTestRequest(*update).Expand(knownExpandTestOptions())
 	req = SetAidFromContext(apiClient.GetConfig().Context, req)
 
 	_, _, err := req.Execute()
@@ -123,4 +123,8 @@ func resourceAgentServerCreate(d *schema.ResourceData, m interface{}) error {
 
 func buildAgentServerStruct(d *schema.ResourceData) *tests.AgentToServerTestRequest {
 	return ResourceBuildStruct(d, &tests.AgentToServerTestRequest{})
+}
+
+func buildAgentServerUpdateStruct(d *schema.ResourceData) *tests.UpdateAgentToServerTestRequest {
+	return ResourceBuildStruct(d, &tests.UpdateAgentToServerTestRequest{})
 }

--- a/thousandeyes/resource_dashboard_test.go
+++ b/thousandeyes/resource_dashboard_test.go
@@ -816,6 +816,55 @@ func TestAccThousandEyesDashboard_testTableTagIDStablePlan(t *testing.T) {
 	})
 }
 
+func TestAccThousandEyesDashboard_colorGridDefaultColumnsStablePlan(t *testing.T) {
+	resourceName := "thousandeyes_dashboard.test_dashboard_color_grid_defaults"
+	cfg := testAccThousandEyesDashboardConfig("acceptance_resources/dashboard/widget_color_grid_defaults.tf")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		CheckDestroy:      testAccCheckDashboardResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: cfg,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "widgets.0.color_grid_config.0.columns", "1"),
+				),
+			},
+			{
+				Config:   cfg,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func TestAccThousandEyesDashboard_alertListDefaultAlertTypesStablePlan(t *testing.T) {
+	resourceName := "thousandeyes_dashboard.test_dashboard_alert_list_defaults"
+	cfg := testAccThousandEyesDashboardConfig("acceptance_resources/dashboard/widget_alert_list_defaults.tf")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		CheckDestroy:      testAccCheckDashboardResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: cfg,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "widgets.0.alert_list_config.0.limit_to", "15"),
+					resource.TestCheckResourceAttr(resourceName, "widgets.0.alert_list_config.0.active_within_value", "7"),
+					resource.TestCheckResourceAttr(resourceName, "widgets.0.alert_list_config.0.active_within_unit", "Days"),
+					resource.TestCheckResourceAttrSet(resourceName, "widgets.0.alert_list_config.0.alert_types.#"),
+				),
+			},
+			{
+				Config:   cfg,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 // TestAccThousandEyesDashboard_removeAllWidgets is a dedicated test for the bug where removing
 // all widget blocks from config produced no diff and left widgets unchanged on the API.
 func TestAccThousandEyesDashboard_removeAllWidgets(t *testing.T) {

--- a/thousandeyes/resource_dashboard_test.go
+++ b/thousandeyes/resource_dashboard_test.go
@@ -437,7 +437,7 @@ func TestAccThousandEyesDashboard(t *testing.T) {
 				resource.TestCheckResourceAttr(resourceNameTestTableWidget, "widgets.0.test_table_config.0.filter.0.filters.0.key", "Test Name"),
 				resource.TestCheckResourceAttr(resourceNameTestTableWidget, "widgets.0.test_table_config.0.filter.0.filters.0.value", "API"),
 				resource.TestCheckResourceAttr(resourceNameTestTableWidget, "widgets.0.test_table_config.0.exclude.0.type", "any"),
-				resource.TestCheckResourceAttr(resourceNameTestTableWidget, "widgets.0.test_table_config.0.exclude.0.filters.0.key", "Test ID"),
+				resource.TestCheckResourceAttr(resourceNameTestTableWidget, "widgets.0.test_table_config.0.exclude.0.filters.0.key", "Tag ID"),
 				resource.TestCheckResourceAttr(resourceNameTestTableWidget, "widgets.0.test_table_config.0.exclude.0.filters.0.value", "123"),
 			},
 			checkUpdateFunc: []resource.TestCheckFunc{
@@ -449,7 +449,7 @@ func TestAccThousandEyesDashboard(t *testing.T) {
 				resource.TestCheckResourceAttr(resourceNameTestTableWidget, "widgets.0.test_table_config.0.filter.0.filters.0.key", "Target"),
 				resource.TestCheckResourceAttr(resourceNameTestTableWidget, "widgets.0.test_table_config.0.filter.0.filters.0.value", "example.com"),
 				resource.TestCheckResourceAttr(resourceNameTestTableWidget, "widgets.0.test_table_config.0.exclude.0.type", "all"),
-				resource.TestCheckResourceAttr(resourceNameTestTableWidget, "widgets.0.test_table_config.0.exclude.0.filters.0.key", "Test ID"),
+				resource.TestCheckResourceAttr(resourceNameTestTableWidget, "widgets.0.test_table_config.0.exclude.0.filters.0.key", "Tag ID"),
 				resource.TestCheckResourceAttr(resourceNameTestTableWidget, "widgets.0.test_table_config.0.exclude.0.filters.0.value", "456"),
 			},
 		},
@@ -783,6 +783,29 @@ func TestAccThousandEyesDashboard_omitDefaultTimespanStablePlan(t *testing.T) {
 				Config: cfg,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "title", "Test Dashboard Omit Default Timespan"),
+				),
+			},
+			{
+				Config:   cfg,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func TestAccThousandEyesDashboard_testTableTagIDStablePlan(t *testing.T) {
+	resourceName := "thousandeyes_dashboard.test_dashboard_test_table_tag_id_stable_plan"
+	cfg := testAccThousandEyesDashboardConfig("acceptance_resources/dashboard/widget_test_table_tag_id_stable_plan.tf")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		CheckDestroy:      testAccCheckDashboardResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: cfg,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "widgets.0.test_table_config.0.filter.0.filters.0.key", "Tag ID"),
 				),
 			},
 			{

--- a/thousandeyes/schemas/dashboard_widget_schema.go
+++ b/thousandeyes/schemas/dashboard_widget_schema.go
@@ -1,11 +1,32 @@
 package schemas
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 type DashboardWidgetSchemaType map[string]*schema.Schema
+
+var deprecatedDashboardFilterProperties = map[string]struct{}{
+	"TEST_LABEL":          {},
+	"AGENT_LABEL":         {},
+	"ENDPOINT_TEST_LABEL": {},
+}
+
+func validateDashboardFilterProperty(v interface{}, path string) ([]string, []error) {
+	value, ok := v.(string)
+	if !ok {
+		return nil, []error{fmt.Errorf("expected %s to be a string", path)}
+	}
+
+	if _, isDeprecated := deprecatedDashboardFilterProperties[value]; isDeprecated {
+		return nil, []error{fmt.Errorf("%s must not use deprecated label filter property %q", path, value)}
+	}
+
+	return nil, nil
+}
 
 var DashboardWidgetSchema = DashboardWidgetSchemaType{
 	"type": {
@@ -142,6 +163,7 @@ var DashboardWidgetSchema = DashboardWidgetSchemaType{
 					Type:        schema.TypeString,
 					Description: "Filter property (e.g., 'TEST', 'AGENT', 'ENDPOINT_MACHINE_ID', 'MONITOR').",
 					Required:    true,
+					ValidateFunc: validateDashboardFilterProperty,
 				},
 				"values": {
 					Type:        schema.TypeSet,
@@ -812,6 +834,7 @@ var NumberCardSchema = map[string]*schema.Schema{
 					Type:        schema.TypeString,
 					Description: "Filter property.",
 					Required:    true,
+					ValidateFunc: validateDashboardFilterProperty,
 				},
 				"values": {
 					Type:        schema.TypeSet,

--- a/thousandeyes/schemas/dashboard_widget_schema.go
+++ b/thousandeyes/schemas/dashboard_widget_schema.go
@@ -631,6 +631,7 @@ var DashboardWidgetSchema = DashboardWidgetSchemaType{
 					Type:        schema.TypeInt,
 					Description: "Number of columns.",
 					Optional:    true,
+					Computed:    true,
 				},
 				"limit": {
 					Type:        schema.TypeInt,
@@ -653,6 +654,7 @@ var DashboardWidgetSchema = DashboardWidgetSchemaType{
 					Type:        schema.TypeSet,
 					Description: "Alert types to include. Empty means all alert types.",
 					Optional:    true,
+					Computed:    true,
 					Elem:        &schema.Schema{Type: schema.TypeString},
 				},
 				"limit_to": {

--- a/thousandeyes/schemas/dashboard_widget_schema.go
+++ b/thousandeyes/schemas/dashboard_widget_schema.go
@@ -439,7 +439,7 @@ var DashboardWidgetSchema = DashboardWidgetSchemaType{
 												"Target",
 												"Test ID",
 												"Test type",
-												"Label ID",
+												"Tag ID",
 											}, false),
 										},
 										"value": {
@@ -485,7 +485,7 @@ var DashboardWidgetSchema = DashboardWidgetSchemaType{
 												"Target",
 												"Test ID",
 												"Test type",
-												"Label ID",
+												"Tag ID",
 											}, false),
 										},
 										"value": {

--- a/thousandeyes/schemas/dashboard_widget_schema_test.go
+++ b/thousandeyes/schemas/dashboard_widget_schema_test.go
@@ -59,3 +59,59 @@ func TestDashboardWidgetSchemaTestTableFilterKeyUsesTagIDOnly(t *testing.T) {
 	_, errs = validate("Label ID", "widgets.0.test_table_config.0.filter.0.filters.0.key")
 	assert.NotEmpty(t, errs)
 }
+
+func TestDashboardWidgetSchemaRejectsDeprecatedCommonFilterProperties(t *testing.T) {
+	propertySchema := getNestedSchemaProperty(t, DashboardWidgetSchema["filter"], "property")
+
+	assertDashboardFilterPropertyValidation(t, propertySchema, "TEST", true)
+	assertDashboardFilterPropertyValidation(t, propertySchema, "AGENT", true)
+	assertDashboardFilterPropertyValidation(t, propertySchema, "ENDPOINT_LABEL", true)
+	assertDashboardFilterPropertyValidation(t, propertySchema, "TEST_LABEL", false)
+	assertDashboardFilterPropertyValidation(t, propertySchema, "AGENT_LABEL", false)
+	assertDashboardFilterPropertyValidation(t, propertySchema, "ENDPOINT_TEST_LABEL", false)
+	assertDashboardFilterPropertyValidation(t, propertySchema, "Test Labels", true)
+	assertDashboardFilterPropertyValidation(t, propertySchema, "Agent Labels", true)
+}
+
+func TestDashboardWidgetSchemaRejectsDeprecatedNumberCardFilterProperties(t *testing.T) {
+	propertySchema := getNestedSchemaProperty(t, &schema.Schema{
+		Elem: &schema.Resource{Schema: NumberCardSchema},
+	}, "filter", "property")
+
+	assertDashboardFilterPropertyValidation(t, propertySchema, "TEST", true)
+	assertDashboardFilterPropertyValidation(t, propertySchema, "AGENT", true)
+	assertDashboardFilterPropertyValidation(t, propertySchema, "ENDPOINT_LABEL", true)
+	assertDashboardFilterPropertyValidation(t, propertySchema, "TEST_LABEL", false)
+	assertDashboardFilterPropertyValidation(t, propertySchema, "AGENT_LABEL", false)
+	assertDashboardFilterPropertyValidation(t, propertySchema, "ENDPOINT_TEST_LABEL", false)
+}
+
+func getNestedSchemaProperty(t *testing.T, root *schema.Schema, keys ...string) *schema.Schema {
+	t.Helper()
+
+	current := root
+	for _, key := range keys {
+		resource, ok := current.Elem.(*schema.Resource)
+		require.True(t, ok)
+
+		current = resource.Schema[key]
+		require.NotNil(t, current)
+	}
+
+	return current
+}
+
+func assertDashboardFilterPropertyValidation(t *testing.T, propertySchema *schema.Schema, value string, valid bool) {
+	t.Helper()
+
+	require.NotNil(t, propertySchema.ValidateFunc)
+
+	_, errs := propertySchema.ValidateFunc(value, "widgets.0.filter.0.property")
+	if valid {
+		assert.Empty(t, errs)
+		return
+	}
+
+	require.NotEmpty(t, errs)
+	assert.ErrorContains(t, errs[0], "deprecated label filter property")
+}

--- a/thousandeyes/schemas/dashboard_widget_schema_test.go
+++ b/thousandeyes/schemas/dashboard_widget_schema_test.go
@@ -21,6 +21,37 @@ func TestDashboardWidgetSchemaFixedTimespanIsComputed(t *testing.T) {
 	assert.True(t, fixedTimespanResource.Schema["unit"].Computed)
 }
 
+func TestDashboardWidgetSchemaColorGridColumnsIsComputed(t *testing.T) {
+	colorGridSchema := DashboardWidgetSchema["color_grid_config"]
+	require.NotNil(t, colorGridSchema)
+
+	colorGridResource, ok := colorGridSchema.Elem.(*schema.Resource)
+	require.True(t, ok)
+
+	columnsSchema := colorGridResource.Schema["columns"]
+	require.NotNil(t, columnsSchema)
+	assert.True(t, columnsSchema.Optional)
+	assert.True(t, columnsSchema.Computed)
+
+	unitSchema := colorGridResource.Schema["unit"]
+	require.NotNil(t, unitSchema)
+	assert.True(t, unitSchema.Optional)
+	assert.False(t, unitSchema.Computed)
+}
+
+func TestDashboardWidgetSchemaAlertListAlertTypesIsComputed(t *testing.T) {
+	alertListSchema := DashboardWidgetSchema["alert_list_config"]
+	require.NotNil(t, alertListSchema)
+
+	alertListResource, ok := alertListSchema.Elem.(*schema.Resource)
+	require.True(t, ok)
+
+	alertTypesSchema := alertListResource.Schema["alert_types"]
+	require.NotNil(t, alertTypesSchema)
+	assert.True(t, alertTypesSchema.Optional)
+	assert.True(t, alertTypesSchema.Computed)
+}
+
 func TestDashboardWidgetSchemaTestTableFilterKeyUsesTagIDOnly(t *testing.T) {
 	testTableSchema := DashboardWidgetSchema["test_table_config"]
 	require.NotNil(t, testTableSchema)

--- a/thousandeyes/schemas/dashboard_widget_schema_test.go
+++ b/thousandeyes/schemas/dashboard_widget_schema_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -18,4 +19,43 @@ func TestDashboardWidgetSchemaFixedTimespanIsComputed(t *testing.T) {
 	require.True(t, ok)
 	assert.True(t, fixedTimespanResource.Schema["value"].Computed)
 	assert.True(t, fixedTimespanResource.Schema["unit"].Computed)
+}
+
+func TestDashboardWidgetSchemaTestTableFilterKeyUsesTagIDOnly(t *testing.T) {
+	testTableSchema := DashboardWidgetSchema["test_table_config"]
+	require.NotNil(t, testTableSchema)
+
+	testTableResource, ok := testTableSchema.Elem.(*schema.Resource)
+	require.True(t, ok)
+
+	filterSchema := testTableResource.Schema["filter"]
+	filterResource, ok := filterSchema.Elem.(*schema.Resource)
+	require.True(t, ok)
+
+	filtersSchema := filterResource.Schema["filters"]
+	filtersResource, ok := filtersSchema.Elem.(*schema.Resource)
+	require.True(t, ok)
+
+	keySchema := filtersResource.Schema["key"]
+	require.NotNil(t, keySchema)
+
+	_, errs := keySchema.ValidateFunc("Tag ID", "widgets.0.test_table_config.0.filter.0.filters.0.key")
+	assert.Empty(t, errs)
+
+	_, errs = keySchema.ValidateFunc("Label ID", "widgets.0.test_table_config.0.filter.0.filters.0.key")
+	assert.NotEmpty(t, errs)
+
+	// Keep a direct guard on the enum list in case the helper implementation changes.
+	validate := validation.StringInSlice([]string{
+		"Anything",
+		"Test Name",
+		"Target",
+		"Test ID",
+		"Test type",
+		"Tag ID",
+	}, false)
+	_, errs = validate("Tag ID", "widgets.0.test_table_config.0.filter.0.filters.0.key")
+	assert.Empty(t, errs)
+	_, errs = validate("Label ID", "widgets.0.test_table_config.0.filter.0.filters.0.key")
+	assert.NotEmpty(t, errs)
 }

--- a/thousandeyes/schemas/oauth_schema.go
+++ b/thousandeyes/schemas/oauth_schema.go
@@ -15,11 +15,6 @@ var oauth = &schema.Schema{
 	Optional:    true,
 	Elem: &schema.Resource{
 		Schema: map[string]*schema.Schema{
-			"config_id": {
-				Type:        schema.TypeString,
-				Description: "The ID of the OAuth configuration.",
-				Required:    true,
-			},
 			"test_url": {
 				Type:        schema.TypeString,
 				Description: "Target for the test.",
@@ -27,16 +22,11 @@ var oauth = &schema.Schema{
 			},
 			"request_method": {
 				Type:        schema.TypeString,
-				Description: "[get, post, put, delete, patch, options, trace] Request method.",
+				Description: "[get, post] Request method.",
 				Optional:    true,
 				ValidateFunc: validation.StringInSlice([]string{
 					"get",
 					"post",
-					"put",
-					"delete",
-					"patch",
-					"options",
-					"trace",
 				}, false),
 			},
 			"post_body": {
@@ -52,15 +42,13 @@ var oauth = &schema.Schema{
 			},
 			"auth_type": {
 				Type:        schema.TypeString,
-				Description: "[none, basic, ntlm, kerberos, oauth] The HTTP authentication type. Defaults to 'none'.",
+				Description: "[none, basic, ntlm] The HTTP authentication type. Defaults to 'none'.",
 				Optional:    true,
 				Default:     "none",
 				ValidateFunc: validation.StringInSlice([]string{
 					"none",
 					"basic",
 					"ntlm",
-					"kerberos",
-					"oauth",
 				}, false),
 			},
 			"username": {

--- a/thousandeyes/util.go
+++ b/thousandeyes/util.go
@@ -609,7 +609,8 @@ func FixReadValues(ctx context.Context, targetMaps map[string]map[string]interfa
 		}
 
 	// Ignore nullable fields (already set); skip assignments for Tags (used in Tags Assignments).
-	case "icon", "description", "legacy_id", "assignments":
+	// Tag filters are not exposed by the provider schema.
+	case "icon", "description", "legacy_id", "assignments", "filters":
 		isTags := ctx.Value(tagsKey)
 		if isTags != nil {
 			*name = ""

--- a/thousandeyes/util_test.go
+++ b/thousandeyes/util_test.go
@@ -65,21 +65,16 @@ func TestResourceReadHTTPServerOAuthState(t *testing.T) {
 	d := getReferenceData(resourceHTTPServer().Schema, map[string]string{})
 
 	remoteResource := tests.NewHttpServerTestResponse(tests.TESTINTERVAL__60, "https://www.thousandeyes.com")
-	configID := "2660950"
 	testURL := "https://auth.example.com/oauth/token"
-	requestMethod := tests.REQUESTMETHOD_GET
 	header := "Authorization: Basic test-client"
 	username := "oauth-user"
-	authType := tests.TESTAUTHTYPE_BASIC
-
-	remoteResource.OAuth = &tests.OAuth{
-		ConfigId:      &configID,
-		TestUrl:       &testURL,
-		RequestMethod: &requestMethod,
-		Headers:       &header,
-		Username:      &username,
-		AuthType:      &authType,
-	}
+	oauth := tests.NewOAuth()
+	oauth.TestUrl = &testURL
+	oauth.Headers = &header
+	oauth.Username = &username
+	setOAuthNamedStringField(t, oauth, "RequestMethod", "get")
+	setOAuthNamedStringField(t, oauth, "AuthType", "basic")
+	remoteResource.OAuth = oauth
 
 	if err := ResourceRead(context.TODO(), d, remoteResource); err != nil {
 		t.Fatalf("ResourceRead returned error: %v", err)
@@ -94,9 +89,6 @@ func TestResourceReadHTTPServerOAuthState(t *testing.T) {
 	}
 
 	oauthState := oauthSet.List()[0].(map[string]interface{})
-	if oauthState["config_id"] != configID {
-		t.Fatalf("unexpected oauth config_id: got %#v want %q", oauthState["config_id"], configID)
-	}
 	if oauthState["test_url"] != testURL {
 		t.Fatalf("unexpected oauth test_url: got %#v want %q", oauthState["test_url"], testURL)
 	}
@@ -106,8 +98,8 @@ func TestResourceReadHTTPServerOAuthState(t *testing.T) {
 	if oauthState["username"] != username {
 		t.Fatalf("unexpected oauth username: got %#v want %q", oauthState["username"], username)
 	}
-	if oauthState["auth_type"] != string(authType) {
-		t.Fatalf("unexpected oauth auth_type: got %#v want %q", oauthState["auth_type"], authType)
+	if oauthState["auth_type"] != "basic" {
+		t.Fatalf("unexpected oauth auth_type: got %#v want %q", oauthState["auth_type"], "basic")
 	}
 }
 

--- a/thousandeyes/widget_alert_list_test.go
+++ b/thousandeyes/widget_alert_list_test.go
@@ -91,3 +91,17 @@ func TestMapAlertListWidget(t *testing.T) {
 	assert.Equal(t, 7, config["active_within_value"])
 	assert.Equal(t, "Days", config["active_within_unit"])
 }
+
+func TestMapAlertListWidgetIncludesDefaultAlertTypes(t *testing.T) {
+	w := dashboards.NewApiAlertListWidget("Alert List")
+	w.SetAlertTypes([]dashboards.LegacyAlertListAlertType{
+		dashboards.LegacyAlertListAlertType("API"),
+		dashboards.LegacyAlertListAlertType("DNS Server"),
+	})
+
+	data, err := mapAlertListWidget(dashboards.ApiAlertListWidgetAsApiWidget(w))
+	assert.NoError(t, err)
+
+	config := data["alert_list_config"].([]interface{})[0].(map[string]interface{})
+	assert.ElementsMatch(t, []interface{}{"API", "DNS Server"}, config["alert_types"].([]interface{}))
+}

--- a/thousandeyes/widget_color_grid_test.go
+++ b/thousandeyes/widget_color_grid_test.go
@@ -75,3 +75,14 @@ func TestMapColorGridWidget(t *testing.T) {
 	assert.NotContains(t, config, "sort_group_by")
 	assert.NotContains(t, config, "sort_group_direction")
 }
+
+func TestMapColorGridWidgetIncludesDefaultColumns(t *testing.T) {
+	w := dashboards.NewApiColorGridWidget("Color Grid")
+	w.SetColumns(1)
+
+	data, err := mapColorGridWidget(dashboards.ApiColorGridWidgetAsApiWidget(w))
+	assert.NoError(t, err)
+
+	config := data["color_grid_config"].([]interface{})[0].(map[string]interface{})
+	assert.Equal(t, 1, config["columns"])
+}

--- a/thousandeyes/widget_mappers.go
+++ b/thousandeyes/widget_mappers.go
@@ -806,12 +806,9 @@ func legacyAlertTypesToInterfaces(values []dashboards.LegacyAlertListAlertType) 
 
 func mapTestTableFilterConfig(filter dashboards.ApiWidgetFilterApiTestTableFilterKey) (map[string]interface{}, error) {
 	result := map[string]interface{}{}
-	if v, ok := filter.GetTypeOk(); ok && v != nil {
-		result["type"] = string(*v)
-	}
-
+	blocks := []interface{}{}
 	if filters, ok := filter.GetFiltersOk(); ok && len(filters) > 0 {
-		blocks := make([]interface{}, 0, len(filters))
+		blocks = make([]interface{}, 0, len(filters))
 		for _, item := range filters {
 			key, ok := item.GetKeyOk()
 			if !ok || key == nil || *key == "" {
@@ -829,6 +826,12 @@ func mapTestTableFilterConfig(filter dashboards.ApiWidgetFilterApiTestTableFilte
 		if len(blocks) > 0 {
 			result["filters"] = blocks
 		}
+	}
+	if len(blocks) == 0 {
+		return result, nil
+	}
+	if v, ok := filter.GetTypeOk(); ok && v != nil {
+		result["type"] = string(*v)
 	}
 	return result, nil
 }

--- a/thousandeyes/widget_test_table_test.go
+++ b/thousandeyes/widget_test_table_test.go
@@ -28,7 +28,7 @@ func TestBuildTestTableWidget(t *testing.T) {
 					map[string]interface{}{
 						"type": "any",
 						"filters": []interface{}{
-							map[string]interface{}{"key": "Label ID", "value": "123"},
+							map[string]interface{}{"key": "Tag ID", "value": "123"},
 						},
 					},
 				},
@@ -48,7 +48,7 @@ func TestBuildTestTableWidget(t *testing.T) {
 	exclude := w.GetExclude()
 	assert.Equal(t, dashboards.TestTableFilterType("any"), (&exclude).GetType())
 	assert.Len(t, (&exclude).GetFilters(), 1)
-	assert.Equal(t, dashboards.TestTableFilterKey("Label ID"), (&exclude).GetFilters()[0].GetKey())
+	assert.Equal(t, dashboards.TestTableFilterKey("Tag ID"), (&exclude).GetFilters()[0].GetKey())
 	assert.Equal(t, "123", (&exclude).GetFilters()[0].GetValue())
 }
 
@@ -76,7 +76,7 @@ func TestMapTestTableWidget(t *testing.T) {
 	exclude.SetFilters([]dashboards.ApiMultiSearchFilterApiTestTableFilterKey{
 		func() dashboards.ApiMultiSearchFilterApiTestTableFilterKey {
 			item := dashboards.NewApiMultiSearchFilterApiTestTableFilterKey()
-			item.SetKey(dashboards.TestTableFilterKey("Label ID"))
+			item.SetKey(dashboards.TESTTABLEFILTERKEY_TAG_ID)
 			item.SetValue("123")
 			return *item
 		}(),
@@ -95,7 +95,7 @@ func TestMapTestTableWidget(t *testing.T) {
 	assert.Equal(t, []interface{}{map[string]interface{}{"key": "Test Name", "value": "API"}}, filterBlock["filters"])
 	excludeBlock := config["exclude"].([]interface{})[0].(map[string]interface{})
 	assert.Equal(t, "any", excludeBlock["type"])
-	assert.Equal(t, []interface{}{map[string]interface{}{"key": "Label ID", "value": "123"}}, excludeBlock["filters"])
+	assert.Equal(t, []interface{}{map[string]interface{}{"key": "Tag ID", "value": "123"}}, excludeBlock["filters"])
 }
 
 func TestMapTestTableWidgetReturnsErrorWhenFilterKeyMissing(t *testing.T) {
@@ -114,4 +114,13 @@ func TestMapTestTableWidgetReturnsErrorWhenFilterKeyMissing(t *testing.T) {
 	_, err := mapTestTableWidget(dashboards.ApiTestTableWidgetAsApiWidget(w))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "missing required key")
+}
+
+func TestMapTestTableFilterConfigOmitsEmptyDefaultBlock(t *testing.T) {
+	filter := dashboards.NewApiWidgetFilterApiTestTableFilterKey()
+	filter.SetType(dashboards.TestTableFilterType("all"))
+
+	data, err := mapTestTableFilterConfig(*filter)
+	require.NoError(t, err)
+	assert.Empty(t, data)
 }


### PR DESCRIPTION
## Summary
- update the provider to thousandeyes-sdk-go v3.0.0-alpha.18
- switch Test Table filters to the native `Tag ID` contract and add stable-plan coverage
- align the provider with the current SDK/API contract for nested HTTP server oauth fields
- reject deprecated dashboard label filter API names in widget filter schemas

## What changed
- bumped the v3 SDK to `v3.0.0-alpha.18`
- updated Test Table schema, mapping, tests, and focused acceptance coverage to use `Tag ID` only
- adjusted the Agent-to-Server update request path and tag read handling for the newer SDK types
- removed nested `http_server.oauth.config_id` and narrowed nested oauth `request_method` and `auth_type` to the values supported by the current SDK
- added validation for dashboard filter `property` fields so `TEST_LABEL`, `AGENT_LABEL`, and `ENDPOINT_TEST_LABEL` are rejected while `ENDPOINT_LABEL` remains valid
- regenerated the HTTP server resource docs to match the current nested oauth contract

## Testing
- provider and schema unit tests passed locally
- focused staging acceptance passed for Test Table dashboard coverage, including the `Tag ID` stable-plan case
