### PR TITLE
fix - Preserve HTTP server OAuth state

### DIFF
--- a/thousandeyes/http_server_headers.go
+++ b/thousandeyes/http_server_headers.go
@@ -110,41 +110,6 @@ func rawConfigOAuthConfigured(d rawConfigReader) bool {
 	return !diags.HasError() && raw.IsKnown() && !raw.IsNull() && raw.LengthInt() != 0
 }
 
-func rawConfigOAuthValue(d rawConfigReader) ([]interface{}, bool) {
-	raw, diags := d.GetRawConfigAt(cty.Path{cty.GetAttrStep{Name: "oauth"}})
-	if diags.HasError() || !raw.IsKnown() || raw.IsNull() || raw.LengthInt() == 0 {
-		return nil, false
-	}
-
-	it := raw.ElementIterator()
-	if !it.Next() {
-		return []interface{}{}, true
-	}
-	_, first := it.Element()
-	if !first.IsKnown() || first.IsNull() {
-		return []interface{}{}, true
-	}
-
-	value := map[string]interface{}{}
-	for _, attr := range []string{
-		"test_url",
-		"request_method",
-		"post_body",
-		"headers",
-		"auth_type",
-		"username",
-		"password",
-	} {
-		if v, ok := ctyStringAttr(first, attr); ok {
-			value[attr] = v
-		}
-	}
-	if len(value) == 0 {
-		return []interface{}{}, true
-	}
-	return []interface{}{value}, true
-}
-
 func stringSliceToInterfaceSlice(v []string) []interface{} {
 	out := make([]interface{}, 0, len(v))
 	for _, item := range v {
@@ -209,15 +174,11 @@ func terraformHTTPServerOAuthValue(oauth *tests.OAuth) []interface{} {
 
 func terraformHTTPServerOAuthStateValue(d rawConfigReader, existing []interface{}, oauth *tests.OAuth) []interface{} {
 	remote := terraformHTTPServerOAuthValue(oauth)
-	configured, ok := rawConfigOAuthValue(d)
-	if !ok || len(configured) == 0 {
-		configured = existing
-	}
 	if len(remote) == 0 {
-		return configured
+		return existing
 	}
 
-	return mergeHTTPServerOAuthValues(remote, configured)
+	return mergeHTTPServerOAuthValues(remote, existing)
 }
 
 func currentHTTPServerOAuthStateValue(d *schema.ResourceData) []interface{} {
@@ -291,18 +252,6 @@ func ctyObjectToNestedStringMap(v cty.Value, attr string) map[string]map[string]
 		}
 	}
 	return out
-}
-
-func ctyStringAttr(v cty.Value, attr string) (string, bool) {
-	if !v.Type().HasAttribute(attr) {
-		return "", false
-	}
-	field := v.GetAttr(attr)
-	if !field.IsKnown() || field.IsNull() {
-		return "", false
-	}
-	field, _ = field.Unmark()
-	return field.AsString(), true
 }
 
 func ctyMapToStringMap(v cty.Value) map[string]string {

--- a/thousandeyes/http_server_headers.go
+++ b/thousandeyes/http_server_headers.go
@@ -110,6 +110,41 @@ func rawConfigOAuthConfigured(d rawConfigReader) bool {
 	return !diags.HasError() && raw.IsKnown() && !raw.IsNull() && raw.LengthInt() != 0
 }
 
+func rawConfigOAuthValue(d rawConfigReader) ([]interface{}, bool) {
+	raw, diags := d.GetRawConfigAt(cty.Path{cty.GetAttrStep{Name: "oauth"}})
+	if diags.HasError() || !raw.IsKnown() || raw.IsNull() || raw.LengthInt() == 0 {
+		return nil, false
+	}
+
+	it := raw.ElementIterator()
+	if !it.Next() {
+		return []interface{}{}, true
+	}
+	_, first := it.Element()
+	if !first.IsKnown() || first.IsNull() {
+		return []interface{}{}, true
+	}
+
+	value := map[string]interface{}{}
+	for _, attr := range []string{
+		"test_url",
+		"request_method",
+		"post_body",
+		"headers",
+		"auth_type",
+		"username",
+		"password",
+	} {
+		if v, ok := ctyStringAttr(first, attr); ok {
+			value[attr] = v
+		}
+	}
+	if len(value) == 0 {
+		return []interface{}{}, true
+	}
+	return []interface{}{value}, true
+}
+
 func stringSliceToInterfaceSlice(v []string) []interface{} {
 	out := make([]interface{}, 0, len(v))
 	for _, item := range v {
@@ -172,6 +207,51 @@ func terraformHTTPServerOAuthValue(oauth *tests.OAuth) []interface{} {
 	return []interface{}{value}
 }
 
+func terraformHTTPServerOAuthStateValue(d rawConfigReader, existing []interface{}, oauth *tests.OAuth) []interface{} {
+	remote := terraformHTTPServerOAuthValue(oauth)
+	configured, ok := rawConfigOAuthValue(d)
+	if !ok || len(configured) == 0 {
+		configured = existing
+	}
+	if len(remote) == 0 {
+		return configured
+	}
+
+	return mergeHTTPServerOAuthValues(remote, configured)
+}
+
+func currentHTTPServerOAuthStateValue(d *schema.ResourceData) []interface{} {
+	oauth, ok := d.Get("oauth").(*schema.Set)
+	if !ok || oauth.Len() == 0 {
+		return nil
+	}
+	return oauth.List()
+}
+
+func mergeHTTPServerOAuthValues(remote, configured []interface{}) []interface{} {
+	if len(remote) == 0 || len(configured) == 0 {
+		return remote
+	}
+
+	remoteMap, ok := remote[0].(map[string]interface{})
+	if !ok {
+		return remote
+	}
+	configuredMap, ok := configured[0].(map[string]interface{})
+	if !ok {
+		return remote
+	}
+
+	merged := make(map[string]interface{}, len(remoteMap)+len(configuredMap))
+	for k, v := range configuredMap {
+		merged[k] = v
+	}
+	for k, v := range remoteMap {
+		merged[k] = v
+	}
+	return []interface{}{merged}
+}
+
 func ctyObjectToStringMap(v cty.Value, attr string) map[string]string {
 	if !v.Type().HasAttribute(attr) {
 		return nil
@@ -211,6 +291,18 @@ func ctyObjectToNestedStringMap(v cty.Value, attr string) map[string]map[string]
 		}
 	}
 	return out
+}
+
+func ctyStringAttr(v cty.Value, attr string) (string, bool) {
+	if !v.Type().HasAttribute(attr) {
+		return "", false
+	}
+	field := v.GetAttr(attr)
+	if !field.IsKnown() || field.IsNull() {
+		return "", false
+	}
+	field, _ = field.Unmark()
+	return field.AsString(), true
 }
 
 func ctyMapToStringMap(v cty.Value) map[string]string {

--- a/thousandeyes/http_server_headers_test.go
+++ b/thousandeyes/http_server_headers_test.go
@@ -155,41 +155,6 @@ func TestRawConfigOAuthConfigured(t *testing.T) {
 	}
 }
 
-func TestRawConfigOAuthValuePreservesConfiguredFields(t *testing.T) {
-	reader := &mockRawConfigReader{
-		values: map[string]mockRawConfigValue{
-			"oauth": {
-				present: true,
-				block: map[string]mockRawConfigValue{
-					"test_url":       {present: true, str: "https://auth.example.com/oauth/token"},
-					"request_method": {present: true, str: "post"},
-					"auth_type":      {present: true, str: "basic"},
-					"username":       {present: true, str: "oauth-user"},
-					"password":       {present: true, str: "oauth-pass"},
-				},
-			},
-		},
-	}
-
-	got, ok := rawConfigOAuthValue(reader)
-	if !ok {
-		t.Fatalf("expected oauth config to be available")
-	}
-
-	want := []interface{}{
-		map[string]interface{}{
-			"test_url":       "https://auth.example.com/oauth/token",
-			"request_method": "post",
-			"auth_type":      "basic",
-			"username":       "oauth-user",
-			"password":       "oauth-pass",
-		},
-	}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("unexpected raw oauth config: got %#v want %#v", got, want)
-	}
-}
-
 func TestTerraformHTTPServerOAuthStateValueFallsBackToConfigWhenAPIOmitsOAuth(t *testing.T) {
 	reader := &mockRawConfigReader{
 		values: map[string]mockRawConfigValue{
@@ -205,10 +170,7 @@ func TestTerraformHTTPServerOAuthStateValueFallsBackToConfigWhenAPIOmitsOAuth(t 
 			},
 		},
 	}
-
-	got := terraformHTTPServerOAuthStateValue(reader, nil, nil)
-
-	want := []interface{}{
+	existing := []interface{}{
 		map[string]interface{}{
 			"test_url":       "https://auth.example.com/oauth/token",
 			"request_method": "post",
@@ -217,8 +179,11 @@ func TestTerraformHTTPServerOAuthStateValueFallsBackToConfigWhenAPIOmitsOAuth(t 
 			"password":       "oauth-pass",
 		},
 	}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("unexpected oauth state fallback: got %#v want %#v", got, want)
+
+	got := terraformHTTPServerOAuthStateValue(reader, existing, nil)
+
+	if !reflect.DeepEqual(got, existing) {
+		t.Fatalf("unexpected oauth state fallback: got %#v want %#v", got, existing)
 	}
 }
 
@@ -237,6 +202,15 @@ func TestTerraformHTTPServerOAuthStateValuePreservesConfigOnlySecret(t *testing.
 			},
 		},
 	}
+	existing := []interface{}{
+		map[string]interface{}{
+			"test_url":       "https://configured.example.com/oauth/token",
+			"request_method": "post",
+			"auth_type":      "basic",
+			"username":       "oauth-user",
+			"password":       "oauth-pass",
+		},
+	}
 
 	remoteURL := "https://remote.example.com/oauth/token"
 	oauth := tests.NewOAuth()
@@ -244,7 +218,7 @@ func TestTerraformHTTPServerOAuthStateValuePreservesConfigOnlySecret(t *testing.
 	setOAuthNamedStringField(t, oauth, "RequestMethod", "post")
 	setOAuthNamedStringField(t, oauth, "AuthType", "basic")
 
-	got := terraformHTTPServerOAuthStateValue(reader, nil, oauth)
+	got := terraformHTTPServerOAuthStateValue(reader, existing, oauth)
 
 	want := []interface{}{
 		map[string]interface{}{
@@ -276,6 +250,38 @@ func TestTerraformHTTPServerOAuthStateValueFallsBackToExistingState(t *testing.T
 
 	if !reflect.DeepEqual(got, existing) {
 		t.Fatalf("expected existing oauth state fallback: got %#v want %#v", got, existing)
+	}
+}
+
+func TestTerraformHTTPServerOAuthStateValueDoesNotSwallowConfigChanges(t *testing.T) {
+	reader := &mockRawConfigReader{
+		values: map[string]mockRawConfigValue{
+			"oauth": {
+				present: true,
+				block: map[string]mockRawConfigValue{
+					"test_url":       {present: true, str: "https://auth.example.com/oauth/token"},
+					"request_method": {present: true, str: "post"},
+					"auth_type":      {present: true, str: "basic"},
+					"username":       {present: true, str: "new-user"},
+					"password":       {present: true, str: "new-pass"},
+				},
+			},
+		},
+	}
+	existing := []interface{}{
+		map[string]interface{}{
+			"test_url":       "https://auth.example.com/oauth/token",
+			"request_method": "post",
+			"auth_type":      "basic",
+			"username":       "old-user",
+			"password":       "old-pass",
+		},
+	}
+
+	got := terraformHTTPServerOAuthStateValue(reader, existing, nil)
+
+	if !reflect.DeepEqual(got, existing) {
+		t.Fatalf("expected read state to preserve prior oauth state, got %#v want %#v", got, existing)
 	}
 }
 

--- a/thousandeyes/http_server_headers_test.go
+++ b/thousandeyes/http_server_headers_test.go
@@ -155,6 +155,130 @@ func TestRawConfigOAuthConfigured(t *testing.T) {
 	}
 }
 
+func TestRawConfigOAuthValuePreservesConfiguredFields(t *testing.T) {
+	reader := &mockRawConfigReader{
+		values: map[string]mockRawConfigValue{
+			"oauth": {
+				present: true,
+				block: map[string]mockRawConfigValue{
+					"test_url":       {present: true, str: "https://auth.example.com/oauth/token"},
+					"request_method": {present: true, str: "post"},
+					"auth_type":      {present: true, str: "basic"},
+					"username":       {present: true, str: "oauth-user"},
+					"password":       {present: true, str: "oauth-pass"},
+				},
+			},
+		},
+	}
+
+	got, ok := rawConfigOAuthValue(reader)
+	if !ok {
+		t.Fatalf("expected oauth config to be available")
+	}
+
+	want := []interface{}{
+		map[string]interface{}{
+			"test_url":       "https://auth.example.com/oauth/token",
+			"request_method": "post",
+			"auth_type":      "basic",
+			"username":       "oauth-user",
+			"password":       "oauth-pass",
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected raw oauth config: got %#v want %#v", got, want)
+	}
+}
+
+func TestTerraformHTTPServerOAuthStateValueFallsBackToConfigWhenAPIOmitsOAuth(t *testing.T) {
+	reader := &mockRawConfigReader{
+		values: map[string]mockRawConfigValue{
+			"oauth": {
+				present: true,
+				block: map[string]mockRawConfigValue{
+					"test_url":       {present: true, str: "https://auth.example.com/oauth/token"},
+					"request_method": {present: true, str: "post"},
+					"auth_type":      {present: true, str: "basic"},
+					"username":       {present: true, str: "oauth-user"},
+					"password":       {present: true, str: "oauth-pass"},
+				},
+			},
+		},
+	}
+
+	got := terraformHTTPServerOAuthStateValue(reader, nil, nil)
+
+	want := []interface{}{
+		map[string]interface{}{
+			"test_url":       "https://auth.example.com/oauth/token",
+			"request_method": "post",
+			"auth_type":      "basic",
+			"username":       "oauth-user",
+			"password":       "oauth-pass",
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected oauth state fallback: got %#v want %#v", got, want)
+	}
+}
+
+func TestTerraformHTTPServerOAuthStateValuePreservesConfigOnlySecret(t *testing.T) {
+	reader := &mockRawConfigReader{
+		values: map[string]mockRawConfigValue{
+			"oauth": {
+				present: true,
+				block: map[string]mockRawConfigValue{
+					"test_url":       {present: true, str: "https://configured.example.com/oauth/token"},
+					"request_method": {present: true, str: "post"},
+					"auth_type":      {present: true, str: "basic"},
+					"username":       {present: true, str: "oauth-user"},
+					"password":       {present: true, str: "oauth-pass"},
+				},
+			},
+		},
+	}
+
+	remoteURL := "https://remote.example.com/oauth/token"
+	oauth := tests.NewOAuth()
+	oauth.TestUrl = &remoteURL
+	setOAuthNamedStringField(t, oauth, "RequestMethod", "post")
+	setOAuthNamedStringField(t, oauth, "AuthType", "basic")
+
+	got := terraformHTTPServerOAuthStateValue(reader, nil, oauth)
+
+	want := []interface{}{
+		map[string]interface{}{
+			"test_url":       remoteURL,
+			"request_method": "post",
+			"auth_type":      "basic",
+			"username":       "oauth-user",
+			"password":       "oauth-pass",
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected merged oauth state: got %#v want %#v", got, want)
+	}
+}
+
+func TestTerraformHTTPServerOAuthStateValueFallsBackToExistingState(t *testing.T) {
+	reader := &mockRawConfigReader{values: map[string]mockRawConfigValue{}}
+	existing := []interface{}{
+		map[string]interface{}{
+			"test_url":       "https://auth.example.com/oauth/token",
+			"request_method": "post",
+			"auth_type":      "basic",
+			"username":       "oauth-user",
+			"password":       "oauth-pass",
+		},
+	}
+
+	got := terraformHTTPServerOAuthStateValue(reader, existing, nil)
+
+	if !reflect.DeepEqual(got, existing) {
+		t.Fatalf("expected existing oauth state fallback: got %#v want %#v", got, existing)
+	}
+}
+
 func TestRawConfigOAuthNotConfigured(t *testing.T) {
 	reader := &mockRawConfigReader{values: map[string]mockRawConfigValue{}}
 
@@ -267,6 +391,7 @@ type mockRawConfigReader struct {
 
 type mockRawConfigValue struct {
 	present bool
+	str     string
 	list    []string
 	block   map[string]mockRawConfigValue
 }
@@ -290,6 +415,10 @@ func (m *mockRawConfigReader) GetRawConfigAt(path cty.Path) (cty.Value, diag.Dia
 }
 
 func (m mockRawConfigValue) toCty() cty.Value {
+	if m.str != "" {
+		return cty.StringVal(m.str)
+	}
+
 	if m.block != nil {
 		obj := make(map[string]cty.Value, len(m.block))
 		for k, v := range m.block {

--- a/thousandeyes/resource_http_server.go
+++ b/thousandeyes/resource_http_server.go
@@ -61,12 +61,13 @@ func resourceHTTPServerRead(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 
+	existingOAuth := currentHTTPServerOAuthStateValue(d)
 	if err := ResourceRead(context.Background(), d, resp); err != nil {
 		return err
 	}
 
-	if rawConfigOAuthConfigured(d) {
-		if err := d.Set("oauth", terraformHTTPServerOAuthValue(resp.OAuth)); err != nil {
+	if rawConfigOAuthConfigured(d) || len(existingOAuth) > 0 {
+		if err := d.Set("oauth", terraformHTTPServerOAuthStateValue(d, existingOAuth, resp.OAuth)); err != nil {
 			return err
 		}
 	} else if err := d.Set("oauth", nil); err != nil {


### PR DESCRIPTION
## What
Preserves configured HTTP server OAuth state when the API response omits OAuth details, while still allowing API-returned OAuth fields to update state when present.

The read path now falls back to prior Terraform state for write-only OAuth fields such as password. It does not copy raw config into state during refresh, so credential changes still produce a plan and are sent through the update path.

## Why
The CEA-backed HTTP server response may omit OAuth details after create/read/import. Without preserving existing OAuth state, Terraform sees drift and plans to re-add the OAuth block on every normal plan.

## Testing
- Unit tests passed for the ThousandEyes provider package.
- Schema tests passed.
- Added regression coverage to ensure OAuth config changes are not swallowed during refresh when the API omits OAuth.
- Staging fresh OAuth HTTP server create/apply/second plan returned no changes.
- Staging old-provider-managed state with migrated HCL returned no changes.
- Staging fresh import succeeded; after one reconciliation apply to seed write-only OAuth fields into state, the next plan returned no changes.
- Old HCL using oauth.config_id is still rejected as expected.