### PR TITLE
fix: track dashboard scale zero presence

### DIFF
--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -212,6 +212,11 @@ Optional:
 - `min_scale` (Number) Minimum scale value for the Y-axis.
 - `unit` (String) Unit for the Y-axis scale.
 
+Read-Only:
+
+- `max_scale_configured` (Boolean) Internal marker indicating whether max_scale was configured.
+- `min_scale_configured` (Boolean) Internal marker indicating whether min_scale was configured.
+
 
 <a id="nestedblock--widgets--color_grid_config"></a>
 ### Nested Schema for `widgets.color_grid_config`
@@ -225,6 +230,11 @@ Optional:
 - `max_scale` (Number) Maximum scale value.
 - `min_scale` (Number) Minimum scale value.
 - `unit` (String) Unit for the scale.
+
+Read-Only:
+
+- `max_scale_configured` (Boolean) Internal marker indicating whether max_scale was configured.
+- `min_scale_configured` (Boolean) Internal marker indicating whether min_scale was configured.
 
 
 <a id="nestedblock--widgets--filter"></a>
@@ -255,6 +265,11 @@ Optional:
 - `max_scale` (Number) Maximum scale value.
 - `min_scale` (Number) Minimum scale value.
 - `unit` (String) Unit for the scale.
+
+Read-Only:
+
+- `max_scale_configured` (Boolean) Internal marker indicating whether max_scale was configured.
+- `min_scale_configured` (Boolean) Internal marker indicating whether min_scale was configured.
 
 
 <a id="nestedblock--widgets--grouped_bar_chart_config"></a>
@@ -344,6 +359,8 @@ Optional:
 Read-Only:
 
 - `id` (String) Identifier of the number card.
+- `max_scale_configured` (Boolean) Internal marker indicating whether max_scale was configured.
+- `min_scale_configured` (Boolean) Internal marker indicating whether min_scale was configured.
 
 <a id="nestedblock--widgets--number_cards--filter"></a>
 ### Nested Schema for `widgets.number_cards.filter`
@@ -393,6 +410,11 @@ Optional:
 - `max_scale` (Number) Maximum scale value for the Y-axis.
 - `min_scale` (Number) Minimum scale value for the Y-axis.
 - `unit` (String) Unit for the Y-axis scale.
+
+Read-Only:
+
+- `max_scale_configured` (Boolean) Internal marker indicating whether max_scale was configured.
+- `min_scale_configured` (Boolean) Internal marker indicating whether min_scale was configured.
 
 
 <a id="nestedblock--widgets--stacked_bar_chart_config"></a>
@@ -473,6 +495,11 @@ Optional:
 - `min_scale` (Number) Minimum scale value for the Y-axis.
 - `show_timeseries_overall_baseline` (Boolean) Displays the overall baseline if set to true.
 - `unit` (String) Unit for the Y-axis scale.
+
+Read-Only:
+
+- `max_scale_configured` (Boolean) Internal marker indicating whether max_scale was configured.
+- `min_scale_configured` (Boolean) Internal marker indicating whether min_scale was configured.
 
 ## Import
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) providing `resource_id`.

--- a/thousandeyes/dashboard_widget_config_normalizer.go
+++ b/thousandeyes/dashboard_widget_config_normalizer.go
@@ -110,9 +110,45 @@ func preserveConfiguredWidgetScalePresence(widgetList []interface{}, priorWidget
 	return preserved
 }
 
+func initializeConfiguredWidgetScalePresenceFromRead(widgetList []interface{}) []interface{} {
+	initialized := cloneInterfaceSlice(widgetList)
+	for i := range initialized {
+		widget, ok := initialized[i].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		initializeConfiguredWidgetScalePresenceFromReadForWidget(widget)
+	}
+	return initialized
+}
+
+func initializeConfiguredWidgetScalePresenceFromReadForWidget(widget map[string]interface{}) {
+	for _, blockName := range dashboardWidgetScaleConfigBlocks {
+		initializeConfiguredScaleBlockFieldsFromRead(widget, blockName)
+	}
+}
+
 func preserveConfiguredWidgetScalePresenceForWidget(widget map[string]interface{}, priorWidget map[string]interface{}) {
 	for _, blockName := range dashboardWidgetScaleConfigBlocks {
 		preserveConfiguredScaleBlockFields(widget, priorWidget, blockName)
+	}
+}
+
+func initializeConfiguredScaleBlockFieldsFromRead(parent map[string]interface{}, blockName string) {
+	blocks, ok := parent[blockName].([]interface{})
+	if !ok {
+		return
+	}
+
+	for _, rawBlock := range blocks {
+		block, ok := rawBlock.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		for _, fieldName := range dashboardWidgetScaleFields {
+			_, configured := block[fieldName]
+			block[fieldName+"_configured"] = configured
+		}
 	}
 }
 

--- a/thousandeyes/dashboard_widget_config_normalizer.go
+++ b/thousandeyes/dashboard_widget_config_normalizer.go
@@ -87,6 +87,66 @@ func markConfiguredWidgetScalePresenceForWidget(widget map[string]interface{}, r
 	}
 }
 
+func preserveConfiguredWidgetScalePresence(widgetList []interface{}, priorWidgetList []interface{}) []interface{} {
+	if len(priorWidgetList) == 0 {
+		return widgetList
+	}
+
+	preserved := cloneInterfaceSlice(widgetList)
+	for i := range preserved {
+		if i >= len(priorWidgetList) {
+			break
+		}
+		widget, ok := preserved[i].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		priorWidget, ok := priorWidgetList[i].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		preserveConfiguredWidgetScalePresenceForWidget(widget, priorWidget)
+	}
+	return preserved
+}
+
+func preserveConfiguredWidgetScalePresenceForWidget(widget map[string]interface{}, priorWidget map[string]interface{}) {
+	for _, blockName := range dashboardWidgetScaleConfigBlocks {
+		preserveConfiguredScaleBlockFields(widget, priorWidget, blockName)
+	}
+}
+
+func preserveConfiguredScaleBlockFields(parent map[string]interface{}, priorParent map[string]interface{}, blockName string) {
+	blocks, ok := parent[blockName].([]interface{})
+	if !ok {
+		return
+	}
+	priorBlocks, ok := priorParent[blockName].([]interface{})
+	if !ok {
+		return
+	}
+
+	for i := range blocks {
+		if i >= len(priorBlocks) {
+			break
+		}
+		block, ok := blocks[i].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		priorBlock, ok := priorBlocks[i].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		for _, fieldName := range dashboardWidgetScaleFields {
+			markerName := fieldName + "_configured"
+			if priorValue, ok := priorBlock[markerName].(bool); ok {
+				block[markerName] = priorValue
+			}
+		}
+	}
+}
+
 func markConfiguredScaleBlockFields(parent map[string]interface{}, rawParent cty.Value, blockName string) {
 	rawBlocks, ok := rawBlockValues(rawParent, blockName)
 	if !ok {

--- a/thousandeyes/dashboard_widget_config_normalizer.go
+++ b/thousandeyes/dashboard_widget_config_normalizer.go
@@ -20,6 +20,20 @@ var dashboardWidgetPresenceSensitiveConfigBlocks = map[string][]string{
 	"multi_metric_table_config": {"compare_to_previous_value"},
 }
 
+var dashboardWidgetScaleConfigBlocks = []string{
+	"geo_map_config",
+	"timeseries_config",
+	"stacked_area_config",
+	"box_and_whiskers_config",
+	"color_grid_config",
+	"number_cards",
+}
+
+var dashboardWidgetScaleFields = []string{
+	"min_scale",
+	"max_scale",
+}
+
 func normalizeConfiguredWidgets(widgetList []interface{}, rawConfig cty.Value) []interface{} {
 	rawWidgets, ok := rawWidgetsFromConfig(rawConfig)
 	if !ok {
@@ -44,6 +58,57 @@ func normalizeConfiguredWidget(widget map[string]interface{}, rawWidget cty.Valu
 	pruneConfiguredFields(widget, rawWidget, dashboardWidgetPresenceSensitiveTopLevelFields)
 	for blockName, fieldNames := range dashboardWidgetPresenceSensitiveConfigBlocks {
 		pruneConfiguredBlockFields(widget, rawWidget, blockName, fieldNames)
+	}
+}
+
+func markConfiguredWidgetScalePresence(widgetList []interface{}, rawConfig cty.Value) []interface{} {
+	rawWidgets, ok := rawWidgetsFromConfig(rawConfig)
+	if !ok {
+		return widgetList
+	}
+
+	marked := cloneInterfaceSlice(widgetList)
+	for i := range marked {
+		if i >= len(rawWidgets) {
+			break
+		}
+		widget, ok := marked[i].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		markConfiguredWidgetScalePresenceForWidget(widget, rawWidgets[i])
+	}
+	return marked
+}
+
+func markConfiguredWidgetScalePresenceForWidget(widget map[string]interface{}, rawWidget cty.Value) {
+	for _, blockName := range dashboardWidgetScaleConfigBlocks {
+		markConfiguredScaleBlockFields(widget, rawWidget, blockName)
+	}
+}
+
+func markConfiguredScaleBlockFields(parent map[string]interface{}, rawParent cty.Value, blockName string) {
+	rawBlocks, ok := rawBlockValues(rawParent, blockName)
+	if !ok {
+		return
+	}
+
+	blocks, ok := parent[blockName].([]interface{})
+	if !ok {
+		return
+	}
+
+	for i := range blocks {
+		if i >= len(rawBlocks) {
+			break
+		}
+		block, ok := blocks[i].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		for _, fieldName := range dashboardWidgetScaleFields {
+			block[fieldName+"_configured"] = rawObjectHasConfiguredAttr(rawBlocks[i], fieldName)
+		}
 	}
 }
 

--- a/thousandeyes/dashboard_widget_config_normalizer_test.go
+++ b/thousandeyes/dashboard_widget_config_normalizer_test.go
@@ -219,6 +219,127 @@ func TestNormalizeConfiguredWidgets_WidgetConfigUnknownScaleIsConfigured(t *test
 	assert.NotContains(t, block, "max_scale")
 }
 
+func TestMarkConfiguredWidgetScalePresence_NumberCardScales(t *testing.T) {
+	widgetList := []interface{}{
+		map[string]interface{}{
+			"type": "Number",
+			"number_cards": []interface{}{
+				map[string]interface{}{
+					"description": "omitted scales",
+					"min_scale":   0.0,
+					"max_scale":   0.0,
+				},
+				map[string]interface{}{
+					"description": "explicit zero scales",
+					"min_scale":   0.0,
+					"max_scale":   0.0,
+				},
+			},
+		},
+	}
+
+	rawConfig := cty.ObjectVal(map[string]cty.Value{
+		"widgets": cty.TupleVal([]cty.Value{
+			cty.ObjectVal(map[string]cty.Value{
+				"type": cty.StringVal("Number"),
+				"number_cards": cty.TupleVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"description": cty.StringVal("omitted scales"),
+					}),
+					cty.ObjectVal(map[string]cty.Value{
+						"description": cty.StringVal("explicit zero scales"),
+						"min_scale":   cty.NumberIntVal(0),
+						"max_scale":   cty.NumberIntVal(0),
+					}),
+				}),
+			}),
+		}),
+	})
+
+	marked := markConfiguredWidgetScalePresence(widgetList, rawConfig)
+	cards := marked[0].(map[string]interface{})["number_cards"].([]interface{})
+	omitted := cards[0].(map[string]interface{})
+	explicitZero := cards[1].(map[string]interface{})
+
+	assert.Equal(t, false, omitted["min_scale_configured"])
+	assert.Equal(t, false, omitted["max_scale_configured"])
+	assert.Equal(t, true, explicitZero["min_scale_configured"])
+	assert.Equal(t, true, explicitZero["max_scale_configured"])
+}
+
+func TestMarkConfiguredWidgetScalePresence_WidgetConfigScales(t *testing.T) {
+	tests := []struct {
+		name       string
+		widgetType string
+		blockName  string
+		rawExtra   map[string]cty.Value
+	}{
+		{name: "map", widgetType: "Map", blockName: "geo_map_config"},
+		{name: "time series line", widgetType: "Time Series: Line", blockName: "timeseries_config"},
+		{
+			name:       "stacked area",
+			widgetType: "Time Series: Stacked Area",
+			blockName:  "stacked_area_config",
+			rawExtra: map[string]cty.Value{
+				"group_by": cty.StringVal("TEST"),
+			},
+		},
+		{name: "box and whiskers", widgetType: "Box and Whiskers", blockName: "box_and_whiskers_config"},
+		{name: "color grid", widgetType: "Color Grid", blockName: "color_grid_config"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			widgetList := []interface{}{
+				map[string]interface{}{
+					"type": tc.widgetType,
+					tc.blockName: []interface{}{
+						map[string]interface{}{
+							"min_scale": 0.0,
+							"max_scale": 0.0,
+						},
+						map[string]interface{}{
+							"min_scale": 0.0,
+							"max_scale": 0.0,
+						},
+					},
+				},
+			}
+
+			firstRawBlock := map[string]cty.Value{}
+			for key, value := range tc.rawExtra {
+				firstRawBlock[key] = value
+			}
+			secondRawBlock := map[string]cty.Value{
+				"min_scale": cty.NumberIntVal(0),
+				"max_scale": cty.NumberIntVal(0),
+			}
+
+			rawConfig := cty.ObjectVal(map[string]cty.Value{
+				"widgets": cty.TupleVal([]cty.Value{
+					cty.ObjectVal(map[string]cty.Value{
+						"type": cty.StringVal(tc.widgetType),
+						tc.blockName: cty.TupleVal([]cty.Value{
+							cty.ObjectVal(firstRawBlock),
+							cty.ObjectVal(secondRawBlock),
+						}),
+					}),
+				}),
+			})
+
+			marked := markConfiguredWidgetScalePresence(widgetList, rawConfig)
+			blocks := marked[0].(map[string]interface{})[tc.blockName].([]interface{})
+			omitted := blocks[0].(map[string]interface{})
+			explicitZero := blocks[1].(map[string]interface{})
+
+			assert.Equal(t, false, omitted["min_scale_configured"])
+			assert.Equal(t, false, omitted["max_scale_configured"])
+			assert.Equal(t, true, explicitZero["min_scale_configured"])
+			assert.Equal(t, true, explicitZero["max_scale_configured"])
+		})
+	}
+}
+
 func TestNormalizeConfiguredWidgets_PrunesOtherPresenceSensitiveFields(t *testing.T) {
 	widgetList := []interface{}{
 		map[string]interface{}{

--- a/thousandeyes/dashboard_widget_config_normalizer_test.go
+++ b/thousandeyes/dashboard_widget_config_normalizer_test.go
@@ -265,6 +265,18 @@ func TestMarkConfiguredWidgetScalePresence_NumberCardScales(t *testing.T) {
 	assert.Equal(t, false, omitted["max_scale_configured"])
 	assert.Equal(t, true, explicitZero["min_scale_configured"])
 	assert.Equal(t, true, explicitZero["max_scale_configured"])
+
+	normalized := normalizeConfiguredWidgets(marked, rawConfig)
+	normalizedCards := normalized[0].(map[string]interface{})["number_cards"].([]interface{})
+	normalizedOmitted := normalizedCards[0].(map[string]interface{})
+	normalizedExplicitZero := normalizedCards[1].(map[string]interface{})
+
+	assert.NotContains(t, normalizedOmitted, "min_scale")
+	assert.NotContains(t, normalizedOmitted, "max_scale")
+	assert.Contains(t, normalizedExplicitZero, "min_scale")
+	assert.Contains(t, normalizedExplicitZero, "max_scale")
+	assert.Contains(t, normalizedOmitted, "min_scale_configured")
+	assert.Contains(t, normalizedOmitted, "max_scale_configured")
 }
 
 func TestMarkConfiguredWidgetScalePresence_WidgetConfigScales(t *testing.T) {
@@ -336,6 +348,18 @@ func TestMarkConfiguredWidgetScalePresence_WidgetConfigScales(t *testing.T) {
 			assert.Equal(t, false, omitted["max_scale_configured"])
 			assert.Equal(t, true, explicitZero["min_scale_configured"])
 			assert.Equal(t, true, explicitZero["max_scale_configured"])
+
+			normalized := normalizeConfiguredWidgets(marked, rawConfig)
+			normalizedBlocks := normalized[0].(map[string]interface{})[tc.blockName].([]interface{})
+			normalizedOmitted := normalizedBlocks[0].(map[string]interface{})
+			normalizedExplicitZero := normalizedBlocks[1].(map[string]interface{})
+
+			assert.NotContains(t, normalizedOmitted, "min_scale")
+			assert.NotContains(t, normalizedOmitted, "max_scale")
+			assert.Contains(t, normalizedExplicitZero, "min_scale")
+			assert.Contains(t, normalizedExplicitZero, "max_scale")
+			assert.Contains(t, normalizedOmitted, "min_scale_configured")
+			assert.Contains(t, normalizedOmitted, "max_scale_configured")
 		})
 	}
 }

--- a/thousandeyes/resource_dashboard.go
+++ b/thousandeyes/resource_dashboard.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"reflect"
 	"time"
 
 	"github.com/hashicorp/go-cty/cty"
@@ -44,6 +45,10 @@ func resourceDashboardCustomizeDiff(_ context.Context, d *schema.ResourceDiff, m
 				return err
 			}
 		}
+	}
+
+	if err := setConfiguredWidgetScalePresenceMarkers(d); err != nil {
+		return err
 	}
 
 	raw := d.Get("widgets")
@@ -118,6 +123,27 @@ func resourceDashboardCustomizeDiff(_ context.Context, d *schema.ResourceDiff, m
 	}
 
 	return nil
+}
+
+func setConfiguredWidgetScalePresenceMarkers(d *schema.ResourceDiff) error {
+	raw := d.Get("widgets")
+	if raw == nil {
+		return nil
+	}
+	widgets, ok := raw.([]interface{})
+	if !ok {
+		return nil
+	}
+
+	markedWidgets := markConfiguredWidgetScalePresence(widgets, d.GetRawConfig())
+	if !interfaceSlicesEqual(widgets, markedWidgets) {
+		return d.SetNew("widgets", markedWidgets)
+	}
+	return nil
+}
+
+func interfaceSlicesEqual(left, right []interface{}) bool {
+	return reflect.DeepEqual(left, right)
 }
 
 // configWidgetsNullOrEmpty reports whether widgets is absent (null) or explicitly empty in

--- a/thousandeyes/resource_dashboard.go
+++ b/thousandeyes/resource_dashboard.go
@@ -410,11 +410,12 @@ func resourceDataApiDashboardMapper(d *schema.ResourceData, dashboard dashboards
 
 	// Handle widgets
 	if widgets := dashboard.GetWidgets(); len(widgets) > 0 {
+		previousWidgets, _ := d.Get("widgets").([]interface{})
 		mappedWidgets, err := MapWidgets(widgets)
 		if err != nil {
 			return err
 		}
-		mappedWidgets = markConfiguredWidgetScalePresence(mappedWidgets, d.GetRawConfig())
+		mappedWidgets = preserveConfiguredWidgetScalePresence(mappedWidgets, previousWidgets)
 		if err := d.Set("widgets", mappedWidgets); err != nil {
 			return err
 		}

--- a/thousandeyes/resource_dashboard.go
+++ b/thousandeyes/resource_dashboard.go
@@ -415,6 +415,7 @@ func resourceDataApiDashboardMapper(d *schema.ResourceData, dashboard dashboards
 		if err != nil {
 			return err
 		}
+		mappedWidgets = initializeConfiguredWidgetScalePresenceFromRead(mappedWidgets)
 		mappedWidgets = preserveConfiguredWidgetScalePresence(mappedWidgets, previousWidgets)
 		if err := d.Set("widgets", mappedWidgets); err != nil {
 			return err

--- a/thousandeyes/resource_dashboard.go
+++ b/thousandeyes/resource_dashboard.go
@@ -414,6 +414,7 @@ func resourceDataApiDashboardMapper(d *schema.ResourceData, dashboard dashboards
 		if err != nil {
 			return err
 		}
+		mappedWidgets = markConfiguredWidgetScalePresence(mappedWidgets, d.GetRawConfig())
 		if err := d.Set("widgets", mappedWidgets); err != nil {
 			return err
 		}

--- a/thousandeyes/resource_dashboard_unit_test.go
+++ b/thousandeyes/resource_dashboard_unit_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/thousandeyes/terraform-provider-thousandeyes/thousandeyes/schemas"
@@ -289,6 +290,118 @@ func TestCustomizeDiff_explicitEmptyWidgets_helperIntegration(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, result.Widgets, "widgets field should be set (not omitted) on the payload")
 	assert.Empty(t, result.GetWidgets(), "widgets slice should be empty so the API clears all widgets")
+}
+
+func TestResourceDashboardCustomizeDiff_NumberCardScalePresenceMarkers(t *testing.T) {
+	tests := []struct {
+		name             string
+		stateMinMarker   string
+		stateMaxMarker   string
+		configCard       map[string]interface{}
+		wantMinMarkerNew string
+		wantMaxMarkerNew string
+	}{
+		{
+			name:           "omitted to explicit zero",
+			stateMinMarker: "false",
+			stateMaxMarker: "false",
+			configCard: map[string]interface{}{
+				"description":  "card",
+				"data_source":  "ALERTS",
+				"metric_group": "ALERTS",
+				"metric":       "ALERT_COUNT_AGENT",
+				"min_scale":    0.0,
+				"max_scale":    0.0,
+			},
+			wantMinMarkerNew: "true",
+			wantMaxMarkerNew: "true",
+		},
+		{
+			name:           "explicit zero to omitted",
+			stateMinMarker: "true",
+			stateMaxMarker: "true",
+			configCard: map[string]interface{}{
+				"description":  "card",
+				"data_source":  "ALERTS",
+				"metric_group": "ALERTS",
+				"metric":       "ALERT_COUNT_AGENT",
+			},
+			wantMinMarkerNew: "false",
+			wantMaxMarkerNew: "false",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			state := &terraform.InstanceState{
+				ID:        "dashboard-123",
+				RawConfig: rawDashboardConfigForNumberCard(tc.configCard),
+				Attributes: map[string]string{
+					"id":                                            "dashboard-123",
+					"title":                                         "T",
+					"widgets.#":                                     "1",
+					"widgets.0.type":                                "Number",
+					"widgets.0.title":                               "Number",
+					"widgets.0.number_cards.#":                      "1",
+					"widgets.0.number_cards.0.description":          "card",
+					"widgets.0.number_cards.0.data_source":          "ALERTS",
+					"widgets.0.number_cards.0.metric_group":         "ALERTS",
+					"widgets.0.number_cards.0.metric":               "ALERT_COUNT_AGENT",
+					"widgets.0.number_cards.0.min_scale":            "0",
+					"widgets.0.number_cards.0.max_scale":            "0",
+					"widgets.0.number_cards.0.min_scale_configured": tc.stateMinMarker,
+					"widgets.0.number_cards.0.max_scale_configured": tc.stateMaxMarker,
+				},
+			}
+			cfg := terraform.NewResourceConfigRaw(map[string]interface{}{
+				"title": "T",
+				"widgets": []interface{}{
+					map[string]interface{}{
+						"type":  "Number",
+						"title": "Number",
+						"number_cards": []interface{}{
+							tc.configCard,
+						},
+					},
+				},
+			})
+
+			diff := dashboardDiff(t, state, cfg)
+			require.NotNil(t, diff)
+			require.Contains(t, diff.Attributes, "widgets.0.number_cards.0.min_scale_configured")
+			require.Contains(t, diff.Attributes, "widgets.0.number_cards.0.max_scale_configured")
+			assert.Equal(t, tc.wantMinMarkerNew, diff.Attributes["widgets.0.number_cards.0.min_scale_configured"].New)
+			assert.Equal(t, tc.wantMaxMarkerNew, diff.Attributes["widgets.0.number_cards.0.max_scale_configured"].New)
+		})
+	}
+}
+
+func rawDashboardConfigForNumberCard(card map[string]interface{}) cty.Value {
+	cardAttrs := map[string]cty.Value{
+		"description":  cty.StringVal(card["description"].(string)),
+		"data_source":  cty.StringVal(card["data_source"].(string)),
+		"metric_group": cty.StringVal(card["metric_group"].(string)),
+		"metric":       cty.StringVal(card["metric"].(string)),
+	}
+	if _, ok := card["min_scale"]; ok {
+		cardAttrs["min_scale"] = cty.NumberIntVal(0)
+	}
+	if _, ok := card["max_scale"]; ok {
+		cardAttrs["max_scale"] = cty.NumberIntVal(0)
+	}
+
+	return cty.ObjectVal(map[string]cty.Value{
+		"title": cty.StringVal("T"),
+		"widgets": cty.TupleVal([]cty.Value{
+			cty.ObjectVal(map[string]cty.Value{
+				"type":  cty.StringVal("Number"),
+				"title": cty.StringVal("Number"),
+				"number_cards": cty.TupleVal([]cty.Value{
+					cty.ObjectVal(cardAttrs),
+				}),
+			}),
+		}),
+	})
 }
 
 func TestResourceDataApiDashboardMapper(t *testing.T) {

--- a/thousandeyes/resource_dashboard_unit_test.go
+++ b/thousandeyes/resource_dashboard_unit_test.go
@@ -572,6 +572,18 @@ func TestResourceDataApiDashboardMapper_DoesNotMarkApiDefaultScaleAsConfigured(t
 	assert.Equal(t, false, cardData["max_scale_configured"])
 }
 
+func TestResourceDataApiDashboardMapper_InitializesScalePresenceFromReadWithoutPriorState(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, schemas.DashboardSchema, map[string]interface{}{})
+	apiDashboard := apiDashboardWithZeroScaleNumberCard()
+
+	require.NoError(t, resourceDataApiDashboardMapper(d, apiDashboard))
+	cards := d.Get("widgets").([]interface{})[0].(map[string]interface{})["number_cards"].([]interface{})
+	cardData := cards[0].(map[string]interface{})
+
+	assert.Equal(t, true, cardData["min_scale_configured"])
+	assert.Equal(t, true, cardData["max_scale_configured"])
+}
+
 func TestResourceDataApiDashboardMapper_PreservesConfiguredZeroScaleFromPriorState(t *testing.T) {
 	d := resourceDataForNumberCardScaleRead(t, "true", "true")
 	apiDashboard := apiDashboardWithZeroScaleNumberCard()

--- a/thousandeyes/resource_dashboard_unit_test.go
+++ b/thousandeyes/resource_dashboard_unit_test.go
@@ -561,7 +561,7 @@ func TestResourceDataApiDashboardMapper(t *testing.T) {
 }
 
 func TestResourceDataApiDashboardMapper_DoesNotMarkApiDefaultScaleAsConfigured(t *testing.T) {
-	d := resourceDataForNumberCardScaleRead(t, false)
+	d := resourceDataForNumberCardScaleRead(t, "false", "false")
 	apiDashboard := apiDashboardWithZeroScaleNumberCard()
 
 	require.NoError(t, resourceDataApiDashboardMapper(d, apiDashboard))
@@ -572,8 +572,8 @@ func TestResourceDataApiDashboardMapper_DoesNotMarkApiDefaultScaleAsConfigured(t
 	assert.Equal(t, false, cardData["max_scale_configured"])
 }
 
-func TestResourceDataApiDashboardMapper_MarksConfiguredZeroScaleFromRawConfig(t *testing.T) {
-	d := resourceDataForNumberCardScaleRead(t, true)
+func TestResourceDataApiDashboardMapper_PreservesConfiguredZeroScaleFromPriorState(t *testing.T) {
+	d := resourceDataForNumberCardScaleRead(t, "true", "true")
 	apiDashboard := apiDashboardWithZeroScaleNumberCard()
 
 	require.NoError(t, resourceDataApiDashboardMapper(d, apiDashboard))
@@ -584,25 +584,26 @@ func TestResourceDataApiDashboardMapper_MarksConfiguredZeroScaleFromRawConfig(t 
 	assert.Equal(t, true, cardData["max_scale_configured"])
 }
 
-func resourceDataForNumberCardScaleRead(t *testing.T, includeScales bool) *schema.ResourceData {
+func resourceDataForNumberCardScaleRead(t *testing.T, minMarker string, maxMarker string) *schema.ResourceData {
 	t.Helper()
 
-	card := map[string]interface{}{
-		"description":  "card",
-		"data_source":  "ALERTS",
-		"metric_group": "ALERTS",
-		"metric":       "ALERT_COUNT_AGENT",
-	}
-	if includeScales {
-		card["min_scale"] = 0.0
-		card["max_scale"] = 0.0
-	}
-
 	d, err := schema.InternalMap(schemas.DashboardSchema).Data(&terraform.InstanceState{
-		ID:        "dashboard-123",
-		RawConfig: rawDashboardConfigForNumberCard(card),
+		ID: "dashboard-123",
 		Attributes: map[string]string{
-			"id": "dashboard-123",
+			"id":                                            "dashboard-123",
+			"title":                                         "T",
+			"widgets.#":                                     "1",
+			"widgets.0.type":                                "Number",
+			"widgets.0.title":                               "Number",
+			"widgets.0.number_cards.#":                      "1",
+			"widgets.0.number_cards.0.description":          "card",
+			"widgets.0.number_cards.0.data_source":          "ALERTS",
+			"widgets.0.number_cards.0.metric_group":         "ALERTS",
+			"widgets.0.number_cards.0.metric":               "ALERT_COUNT_AGENT",
+			"widgets.0.number_cards.0.min_scale":            "0",
+			"widgets.0.number_cards.0.max_scale":            "0",
+			"widgets.0.number_cards.0.min_scale_configured": minMarker,
+			"widgets.0.number_cards.0.max_scale_configured": maxMarker,
 		},
 	}, nil)
 	require.NoError(t, err)

--- a/thousandeyes/resource_dashboard_unit_test.go
+++ b/thousandeyes/resource_dashboard_unit_test.go
@@ -560,6 +560,72 @@ func TestResourceDataApiDashboardMapper(t *testing.T) {
 	}
 }
 
+func TestResourceDataApiDashboardMapper_DoesNotMarkApiDefaultScaleAsConfigured(t *testing.T) {
+	d := resourceDataForNumberCardScaleRead(t, false)
+	apiDashboard := apiDashboardWithZeroScaleNumberCard()
+
+	require.NoError(t, resourceDataApiDashboardMapper(d, apiDashboard))
+	cards := d.Get("widgets").([]interface{})[0].(map[string]interface{})["number_cards"].([]interface{})
+	cardData := cards[0].(map[string]interface{})
+
+	assert.Equal(t, false, cardData["min_scale_configured"])
+	assert.Equal(t, false, cardData["max_scale_configured"])
+}
+
+func TestResourceDataApiDashboardMapper_MarksConfiguredZeroScaleFromRawConfig(t *testing.T) {
+	d := resourceDataForNumberCardScaleRead(t, true)
+	apiDashboard := apiDashboardWithZeroScaleNumberCard()
+
+	require.NoError(t, resourceDataApiDashboardMapper(d, apiDashboard))
+	cards := d.Get("widgets").([]interface{})[0].(map[string]interface{})["number_cards"].([]interface{})
+	cardData := cards[0].(map[string]interface{})
+
+	assert.Equal(t, true, cardData["min_scale_configured"])
+	assert.Equal(t, true, cardData["max_scale_configured"])
+}
+
+func resourceDataForNumberCardScaleRead(t *testing.T, includeScales bool) *schema.ResourceData {
+	t.Helper()
+
+	card := map[string]interface{}{
+		"description":  "card",
+		"data_source":  "ALERTS",
+		"metric_group": "ALERTS",
+		"metric":       "ALERT_COUNT_AGENT",
+	}
+	if includeScales {
+		card["min_scale"] = 0.0
+		card["max_scale"] = 0.0
+	}
+
+	d, err := schema.InternalMap(schemas.DashboardSchema).Data(&terraform.InstanceState{
+		ID:        "dashboard-123",
+		RawConfig: rawDashboardConfigForNumberCard(card),
+		Attributes: map[string]string{
+			"id": "dashboard-123",
+		},
+	}, nil)
+	require.NoError(t, err)
+	return d
+}
+
+func apiDashboardWithZeroScaleNumberCard() dashboards.ApiDashboard {
+	apiDashboard := dashboards.NewApiDashboard()
+	apiDashboard.SetTitle("T")
+	widget := dashboards.NewApiNumbersCardWidget("Number")
+	widget.SetTitle("Number")
+	card := dashboards.NewApiNumbersCard()
+	card.SetDescription("card")
+	card.SetDataSource(dashboards.NumbersCardDatasource("ALERTS"))
+	card.SetMetricGroup(dashboards.MetricGroup("ALERTS"))
+	card.SetMetric(dashboards.DashboardMetric("ALERT_COUNT_AGENT"))
+	card.SetMinScale(0)
+	card.SetMaxScale(0)
+	widget.SetNumberCards([]dashboards.ApiNumbersCard{*card})
+	apiDashboard.SetWidgets([]dashboards.ApiWidget{dashboards.ApiNumbersCardWidgetAsApiWidget(widget)})
+	return *apiDashboard
+}
+
 func TestMapNumberCards_omitsUnsetScales(t *testing.T) {
 	card := dashboards.NewApiNumbersCard()
 	card.SetDescription("No scales")

--- a/thousandeyes/schemas/dashboard_widget_schema.go
+++ b/thousandeyes/schemas/dashboard_widget_schema.go
@@ -188,12 +188,20 @@ var DashboardWidgetSchema = DashboardWidgetSchemaType{
 					Type:        schema.TypeFloat,
 					Description: "Minimum scale value.",
 					Optional:    true,
+				},
+				"min_scale_configured": {
+					Type:        schema.TypeBool,
+					Description: "Internal marker indicating whether min_scale was configured.",
 					Computed:    true,
 				},
 				"max_scale": {
 					Type:        schema.TypeFloat,
 					Description: "Maximum scale value.",
 					Optional:    true,
+				},
+				"max_scale_configured": {
+					Type:        schema.TypeBool,
+					Description: "Internal marker indicating whether max_scale was configured.",
 					Computed:    true,
 				},
 				"unit": {
@@ -253,12 +261,20 @@ var DashboardWidgetSchema = DashboardWidgetSchemaType{
 					Type:        schema.TypeFloat,
 					Description: "Minimum scale value for the Y-axis.",
 					Optional:    true,
+				},
+				"min_scale_configured": {
+					Type:        schema.TypeBool,
+					Description: "Internal marker indicating whether min_scale was configured.",
 					Computed:    true,
 				},
 				"max_scale": {
 					Type:        schema.TypeFloat,
 					Description: "Maximum scale value for the Y-axis.",
 					Optional:    true,
+				},
+				"max_scale_configured": {
+					Type:        schema.TypeBool,
+					Description: "Internal marker indicating whether max_scale was configured.",
 					Computed:    true,
 				},
 				"unit": {
@@ -301,12 +317,20 @@ var DashboardWidgetSchema = DashboardWidgetSchemaType{
 					Type:        schema.TypeFloat,
 					Description: "Minimum scale value for the Y-axis.",
 					Optional:    true,
+				},
+				"min_scale_configured": {
+					Type:        schema.TypeBool,
+					Description: "Internal marker indicating whether min_scale was configured.",
 					Computed:    true,
 				},
 				"max_scale": {
 					Type:        schema.TypeFloat,
 					Description: "Maximum scale value for the Y-axis.",
 					Optional:    true,
+				},
+				"max_scale_configured": {
+					Type:        schema.TypeBool,
+					Description: "Internal marker indicating whether max_scale was configured.",
 					Computed:    true,
 				},
 				"unit": {
@@ -354,12 +378,20 @@ var DashboardWidgetSchema = DashboardWidgetSchemaType{
 					Type:        schema.TypeFloat,
 					Description: "Minimum scale value for the Y-axis.",
 					Optional:    true,
+				},
+				"min_scale_configured": {
+					Type:        schema.TypeBool,
+					Description: "Internal marker indicating whether min_scale was configured.",
 					Computed:    true,
 				},
 				"max_scale": {
 					Type:        schema.TypeFloat,
 					Description: "Maximum scale value for the Y-axis.",
 					Optional:    true,
+				},
+				"max_scale_configured": {
+					Type:        schema.TypeBool,
+					Description: "Internal marker indicating whether max_scale was configured.",
 					Computed:    true,
 				},
 				"unit": {
@@ -622,12 +654,20 @@ var DashboardWidgetSchema = DashboardWidgetSchemaType{
 					Type:        schema.TypeFloat,
 					Description: "Minimum scale value.",
 					Optional:    true,
+				},
+				"min_scale_configured": {
+					Type:        schema.TypeBool,
+					Description: "Internal marker indicating whether min_scale was configured.",
 					Computed:    true,
 				},
 				"max_scale": {
 					Type:        schema.TypeFloat,
 					Description: "Maximum scale value.",
 					Optional:    true,
+				},
+				"max_scale_configured": {
+					Type:        schema.TypeBool,
+					Description: "Internal marker indicating whether max_scale was configured.",
 					Computed:    true,
 				},
 				"unit": {
@@ -763,12 +803,20 @@ var NumberCardSchema = map[string]*schema.Schema{
 		Type:        schema.TypeFloat,
 		Description: "Minimum scale configured for the card.",
 		Optional:    true,
+	},
+	"min_scale_configured": {
+		Type:        schema.TypeBool,
+		Description: "Internal marker indicating whether min_scale was configured.",
 		Computed:    true,
 	},
 	"max_scale": {
 		Type:        schema.TypeFloat,
 		Description: "Maximum scale configured for the card.",
 		Optional:    true,
+	},
+	"max_scale_configured": {
+		Type:        schema.TypeBool,
+		Description: "Internal marker indicating whether max_scale was configured.",
 		Computed:    true,
 	},
 	"unit": {

--- a/thousandeyes/schemas/dashboard_widget_schema_test.go
+++ b/thousandeyes/schemas/dashboard_widget_schema_test.go
@@ -117,6 +117,65 @@ func TestDashboardWidgetSchemaRejectsDeprecatedNumberCardFilterProperties(t *tes
 	assertDashboardFilterPropertyValidation(t, propertySchema, "ENDPOINT_TEST_LABEL", false)
 }
 
+func TestDashboardWidgetScaleFieldsUseConfiguredMarkers(t *testing.T) {
+	tests := []struct {
+		name   string
+		schema map[string]*schema.Schema
+	}{
+		{
+			name: "geo map",
+			schema: DashboardWidgetSchema["geo_map_config"].
+				Elem.(*schema.Resource).Schema,
+		},
+		{
+			name: "timeseries",
+			schema: DashboardWidgetSchema["timeseries_config"].
+				Elem.(*schema.Resource).Schema,
+		},
+		{
+			name: "stacked area",
+			schema: DashboardWidgetSchema["stacked_area_config"].
+				Elem.(*schema.Resource).Schema,
+		},
+		{
+			name: "box and whiskers",
+			schema: DashboardWidgetSchema["box_and_whiskers_config"].
+				Elem.(*schema.Resource).Schema,
+		},
+		{
+			name: "color grid",
+			schema: DashboardWidgetSchema["color_grid_config"].
+				Elem.(*schema.Resource).Schema,
+		},
+		{
+			name:   "number card",
+			schema: NumberCardSchema,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assertScaleSchemaHasConfiguredMarker(t, tc.schema, "min_scale")
+			assertScaleSchemaHasConfiguredMarker(t, tc.schema, "max_scale")
+		})
+	}
+}
+
+func assertScaleSchemaHasConfiguredMarker(t *testing.T, blockSchema map[string]*schema.Schema, fieldName string) {
+	t.Helper()
+
+	scaleSchema := blockSchema[fieldName]
+	require.NotNil(t, scaleSchema)
+	assert.True(t, scaleSchema.Optional)
+	assert.False(t, scaleSchema.Computed)
+
+	markerSchema := blockSchema[fieldName+"_configured"]
+	require.NotNil(t, markerSchema)
+	assert.False(t, markerSchema.Optional)
+	assert.True(t, markerSchema.Computed)
+	assert.Equal(t, schema.TypeBool, markerSchema.Type)
+}
+
 func getNestedSchemaProperty(t *testing.T, root *schema.Schema, keys ...string) *schema.Schema {
 	t.Helper()
 


### PR DESCRIPTION
## Summary

- Add nested computed presence markers for dashboard widget `min_scale` and `max_scale` fields across Number cards and chart config blocks.
- Remove `Computed` from the public `min_scale` / `max_scale` fields so user config owns those fields.
- Populate marker values from raw Terraform config during `CustomizeDiff`, forcing diffs for both omitted-to-zero and zero-to-omitted scale transitions.
- Preserve marker values across read/refresh from prior state so refresh does not hide `0 -> null` before diffing.
- Keep API payload normalization behavior intact: omitted scale fields are omitted from update payloads, while explicit zero scale fields are sent as `0`.

## Why

Terraform SDK nested state materializes omitted optional numeric fields as `0`, so Terraform could not distinguish omitted scale fields from explicitly configured zero values. That made both `null -> 0` and `0 -> null` disappear from plans.

The internal marker fields carry the only bit Terraform needs: whether the user configured each scale field. The public HCL remains unchanged.

## Test Plan

- [x] `go test ./thousandeyes`
- [x] `go test ./...`
- [x] Mock Terraform CLI sanity check with a local provider dev override:
  - omitted `min_scale` / `max_scale` -> explicit `0` plans marker changes `false -> true` and applies
  - explicit `0` -> omitted plans marker changes `true -> false` and applies
  - explicit zero update payload includes `minScale: 0` / `maxScale: 0`
  - omitted update payload excludes `minScale` / `maxScale`
