### PR TITLE
fix: Validate deprecated dashboard labels in group-by schema fields

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/terraform-plugin-docs v0.21.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.36.1
 	github.com/stretchr/testify v1.8.4
-	github.com/thousandeyes/thousandeyes-sdk-go/v3 v3.0.0-alpha.19
+	github.com/thousandeyes/thousandeyes-sdk-go/v3 v3.0.0-alpha.20
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/terraform-plugin-docs v0.21.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.36.1
 	github.com/stretchr/testify v1.8.4
-	github.com/thousandeyes/thousandeyes-sdk-go/v3 v3.0.0-alpha.18
+	github.com/thousandeyes/thousandeyes-sdk-go/v3 v3.0.0-alpha.19
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -193,10 +193,8 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/thousandeyes/thousandeyes-sdk-go/v3 v3.0.0-alpha.18 h1:ruCDKW7t+e9Sk1uqZLEiyeICPUVmycgNn9exYTiMOpE=
-github.com/thousandeyes/thousandeyes-sdk-go/v3 v3.0.0-alpha.18/go.mod h1:EWD+kNN2rC06wBi+KB9dIOM+4WJin7VZjqcFSgHF+Ow=
-github.com/thousandeyes/thousandeyes-sdk-go/v3 v3.0.0-alpha.19 h1:2dxofBrY3YNQggSo9eBlVW2/GkR4eHfk0jykW3kvXCg=
-github.com/thousandeyes/thousandeyes-sdk-go/v3 v3.0.0-alpha.19/go.mod h1:EWD+kNN2rC06wBi+KB9dIOM+4WJin7VZjqcFSgHF+Ow=
+github.com/thousandeyes/thousandeyes-sdk-go/v3 v3.0.0-alpha.20 h1:8QE4HABonvlfuD1M5quR//fvV0bl8bVROeU3rh3aEMY=
+github.com/thousandeyes/thousandeyes-sdk-go/v3 v3.0.0-alpha.20/go.mod h1:EWD+kNN2rC06wBi+KB9dIOM+4WJin7VZjqcFSgHF+Ow=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/go.sum
+++ b/go.sum
@@ -195,6 +195,8 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/thousandeyes/thousandeyes-sdk-go/v3 v3.0.0-alpha.18 h1:ruCDKW7t+e9Sk1uqZLEiyeICPUVmycgNn9exYTiMOpE=
 github.com/thousandeyes/thousandeyes-sdk-go/v3 v3.0.0-alpha.18/go.mod h1:EWD+kNN2rC06wBi+KB9dIOM+4WJin7VZjqcFSgHF+Ow=
+github.com/thousandeyes/thousandeyes-sdk-go/v3 v3.0.0-alpha.19 h1:2dxofBrY3YNQggSo9eBlVW2/GkR4eHfk0jykW3kvXCg=
+github.com/thousandeyes/thousandeyes-sdk-go/v3 v3.0.0-alpha.19/go.mod h1:EWD+kNN2rC06wBi+KB9dIOM+4WJin7VZjqcFSgHF+Ow=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/thousandeyes/schemas/dashboard_widget_schema.go
+++ b/thousandeyes/schemas/dashboard_widget_schema.go
@@ -9,20 +9,20 @@ import (
 
 type DashboardWidgetSchemaType map[string]*schema.Schema
 
-var deprecatedDashboardFilterProperties = map[string]struct{}{
+var deprecatedDashboardLabels = map[string]struct{}{
 	"TEST_LABEL":          {},
 	"AGENT_LABEL":         {},
 	"ENDPOINT_TEST_LABEL": {},
 }
 
-func validateDashboardFilterProperty(v interface{}, path string) ([]string, []error) {
+func validateDashboardLabel(v interface{}, path string) ([]string, []error) {
 	value, ok := v.(string)
 	if !ok {
 		return nil, []error{fmt.Errorf("expected %s to be a string", path)}
 	}
 
-	if _, isDeprecated := deprecatedDashboardFilterProperties[value]; isDeprecated {
-		return nil, []error{fmt.Errorf("%s must not use deprecated label filter property %q", path, value)}
+	if _, isDeprecated := deprecatedDashboardLabels[value]; isDeprecated {
+		return nil, []error{fmt.Errorf("%s must not use deprecated label value %q", path, value)}
 	}
 
 	return nil, nil
@@ -163,7 +163,7 @@ var DashboardWidgetSchema = DashboardWidgetSchemaType{
 					Type:         schema.TypeString,
 					Description:  "Filter property (e.g., 'TEST', 'AGENT', 'ENDPOINT_MACHINE_ID', 'MONITOR').",
 					Required:     true,
-					ValidateFunc: validateDashboardFilterProperty,
+					ValidateFunc: validateDashboardLabel,
 				},
 				"values": {
 					Type:        schema.TypeSet,
@@ -202,10 +202,11 @@ var DashboardWidgetSchema = DashboardWidgetSchemaType{
 					Optional:    true,
 				},
 				"group_by": {
-					Type:        schema.TypeString,
-					Description: "Group by property.",
-					Optional:    true,
-					Computed:    true,
+					Type:         schema.TypeString,
+					Description:  "Group by property.",
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: validateDashboardLabel,
 				},
 				"is_geo_map_per_test": {
 					Type:        schema.TypeBool,
@@ -267,10 +268,11 @@ var DashboardWidgetSchema = DashboardWidgetSchemaType{
 					Optional:    true,
 				},
 				"group_by": {
-					Type:        schema.TypeString,
-					Description: "Group by property.",
-					Optional:    true,
-					Computed:    true,
+					Type:         schema.TypeString,
+					Description:  "Group by property.",
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: validateDashboardLabel,
 				},
 				"show_timeseries_overall_baseline": {
 					Type:        schema.TypeBool,
@@ -315,9 +317,10 @@ var DashboardWidgetSchema = DashboardWidgetSchemaType{
 					Optional:    true,
 				},
 				"group_by": {
-					Type:        schema.TypeString,
-					Description: "Group by property.",
-					Required:    true,
+					Type:         schema.TypeString,
+					Description:  "Group by property.",
+					Required:     true,
+					ValidateFunc: validateDashboardLabel,
 				},
 			},
 		},
@@ -333,9 +336,10 @@ var DashboardWidgetSchema = DashboardWidgetSchemaType{
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"group_by": {
-					Type:        schema.TypeString,
-					Description: "Group by property.",
-					Required:    true,
+					Type:         schema.TypeString,
+					Description:  "Group by property.",
+					Required:     true,
+					ValidateFunc: validateDashboardLabel,
 				},
 			},
 		},
@@ -368,10 +372,11 @@ var DashboardWidgetSchema = DashboardWidgetSchemaType{
 					Optional:    true,
 				},
 				"group_by": {
-					Type:        schema.TypeString,
-					Description: "Group by property.",
-					Optional:    true,
-					Computed:    true,
+					Type:         schema.TypeString,
+					Description:  "Group by property.",
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: validateDashboardLabel,
 				},
 			},
 		},
@@ -415,14 +420,16 @@ var DashboardWidgetSchema = DashboardWidgetSchemaType{
 					Computed:    true,
 				},
 				"row_group_by": {
-					Type:        schema.TypeString,
-					Description: "Group rows by property.",
-					Optional:    true,
+					Type:         schema.TypeString,
+					Description:  "Group rows by property.",
+					Optional:     true,
+					ValidateFunc: validateDashboardLabel,
 				},
 				"column_group_by": {
-					Type:        schema.TypeString,
-					Description: "Group columns by property.",
-					Optional:    true,
+					Type:         schema.TypeString,
+					Description:  "Group columns by property.",
+					Optional:     true,
+					ValidateFunc: validateDashboardLabel,
 				},
 				"limit": {
 					Type:        schema.TypeInt,
@@ -546,9 +553,10 @@ var DashboardWidgetSchema = DashboardWidgetSchemaType{
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"axis_group_by": {
-					Type:        schema.TypeString,
-					Description: "Axis grouping property.",
-					Optional:    true,
+					Type:         schema.TypeString,
+					Description:  "Axis grouping property.",
+					Optional:     true,
+					ValidateFunc: validateDashboardLabel,
 				},
 				"limit": {
 					Type:        schema.TypeInt,
@@ -580,14 +588,16 @@ var DashboardWidgetSchema = DashboardWidgetSchemaType{
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"group_by": {
-					Type:        schema.TypeString,
-					Description: "Group bars by property.",
-					Optional:    true,
+					Type:         schema.TypeString,
+					Description:  "Group bars by property.",
+					Optional:     true,
+					ValidateFunc: validateDashboardLabel,
 				},
 				"axis_group_by": {
-					Type:        schema.TypeString,
-					Description: "Axis grouping property.",
-					Optional:    true,
+					Type:         schema.TypeString,
+					Description:  "Axis grouping property.",
+					Optional:     true,
+					ValidateFunc: validateDashboardLabel,
 				},
 				"limit": {
 					Type:        schema.TypeInt,
@@ -722,10 +732,11 @@ var DashboardWidgetSchema = DashboardWidgetSchemaType{
 					Computed:    true,
 				},
 				"row_group_by": {
-					Type:        schema.TypeString,
-					Description: "Property to group rows by.",
-					Optional:    true,
-					Computed:    true,
+					Type:         schema.TypeString,
+					Description:  "Property to group rows by.",
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: validateDashboardLabel,
 				},
 				"limit": {
 					Type:        schema.TypeInt,
@@ -860,7 +871,7 @@ var NumberCardSchema = map[string]*schema.Schema{
 					Type:         schema.TypeString,
 					Description:  "Filter property.",
 					Required:     true,
-					ValidateFunc: validateDashboardFilterProperty,
+					ValidateFunc: validateDashboardLabel,
 				},
 				"values": {
 					Type:        schema.TypeSet,

--- a/thousandeyes/schemas/dashboard_widget_schema_test.go
+++ b/thousandeyes/schemas/dashboard_widget_schema_test.go
@@ -94,14 +94,14 @@ func TestDashboardWidgetSchemaTestTableFilterKeyUsesTagIDOnly(t *testing.T) {
 func TestDashboardWidgetSchemaRejectsDeprecatedCommonFilterProperties(t *testing.T) {
 	propertySchema := getNestedSchemaProperty(t, DashboardWidgetSchema["filter"], "property")
 
-	assertDashboardFilterPropertyValidation(t, propertySchema, "TEST", true)
-	assertDashboardFilterPropertyValidation(t, propertySchema, "AGENT", true)
-	assertDashboardFilterPropertyValidation(t, propertySchema, "ENDPOINT_LABEL", true)
-	assertDashboardFilterPropertyValidation(t, propertySchema, "TEST_LABEL", false)
-	assertDashboardFilterPropertyValidation(t, propertySchema, "AGENT_LABEL", false)
-	assertDashboardFilterPropertyValidation(t, propertySchema, "ENDPOINT_TEST_LABEL", false)
-	assertDashboardFilterPropertyValidation(t, propertySchema, "Test Labels", true)
-	assertDashboardFilterPropertyValidation(t, propertySchema, "Agent Labels", true)
+	assertDashboardLabelValidation(t, propertySchema, "widgets.0.filter.0.property", "TEST", true)
+	assertDashboardLabelValidation(t, propertySchema, "widgets.0.filter.0.property", "AGENT", true)
+	assertDashboardLabelValidation(t, propertySchema, "widgets.0.filter.0.property", "ENDPOINT_LABEL", true)
+	assertDashboardLabelValidation(t, propertySchema, "widgets.0.filter.0.property", "TEST_LABEL", false)
+	assertDashboardLabelValidation(t, propertySchema, "widgets.0.filter.0.property", "AGENT_LABEL", false)
+	assertDashboardLabelValidation(t, propertySchema, "widgets.0.filter.0.property", "ENDPOINT_TEST_LABEL", false)
+	assertDashboardLabelValidation(t, propertySchema, "widgets.0.filter.0.property", "Test Labels", true)
+	assertDashboardLabelValidation(t, propertySchema, "widgets.0.filter.0.property", "Agent Labels", true)
 }
 
 func TestDashboardWidgetSchemaRejectsDeprecatedNumberCardFilterProperties(t *testing.T) {
@@ -109,12 +109,99 @@ func TestDashboardWidgetSchemaRejectsDeprecatedNumberCardFilterProperties(t *tes
 		Elem: &schema.Resource{Schema: NumberCardSchema},
 	}, "filter", "property")
 
-	assertDashboardFilterPropertyValidation(t, propertySchema, "TEST", true)
-	assertDashboardFilterPropertyValidation(t, propertySchema, "AGENT", true)
-	assertDashboardFilterPropertyValidation(t, propertySchema, "ENDPOINT_LABEL", true)
-	assertDashboardFilterPropertyValidation(t, propertySchema, "TEST_LABEL", false)
-	assertDashboardFilterPropertyValidation(t, propertySchema, "AGENT_LABEL", false)
-	assertDashboardFilterPropertyValidation(t, propertySchema, "ENDPOINT_TEST_LABEL", false)
+	assertDashboardLabelValidation(t, propertySchema, "widgets.0.number_card_config.0.filter.0.property", "TEST", true)
+	assertDashboardLabelValidation(t, propertySchema, "widgets.0.number_card_config.0.filter.0.property", "AGENT", true)
+	assertDashboardLabelValidation(t, propertySchema, "widgets.0.number_card_config.0.filter.0.property", "ENDPOINT_LABEL", true)
+	assertDashboardLabelValidation(t, propertySchema, "widgets.0.number_card_config.0.filter.0.property", "TEST_LABEL", false)
+	assertDashboardLabelValidation(t, propertySchema, "widgets.0.number_card_config.0.filter.0.property", "AGENT_LABEL", false)
+	assertDashboardLabelValidation(t, propertySchema, "widgets.0.number_card_config.0.filter.0.property", "ENDPOINT_TEST_LABEL", false)
+}
+
+func TestDashboardWidgetSchemaRejectsDeprecatedGroupByLabelProperties(t *testing.T) {
+	testCases := []struct {
+		name      string
+		root      *schema.Schema
+		keys      []string
+		fieldPath string
+	}{
+		{
+			name:      "timeseries group_by",
+			root:      DashboardWidgetSchema["timeseries_config"],
+			keys:      []string{"group_by"},
+			fieldPath: "widgets.0.timeseries_config.0.group_by",
+		},
+		{
+			name:      "stacked area group_by",
+			root:      DashboardWidgetSchema["stacked_area_config"],
+			keys:      []string{"group_by"},
+			fieldPath: "widgets.0.stacked_area_config.0.group_by",
+		},
+		{
+			name:      "pie chart group_by",
+			root:      DashboardWidgetSchema["pie_chart_config"],
+			keys:      []string{"group_by"},
+			fieldPath: "widgets.0.pie_chart_config.0.group_by",
+		},
+		{
+			name:      "box and whiskers group_by",
+			root:      DashboardWidgetSchema["box_and_whiskers_config"],
+			keys:      []string{"group_by"},
+			fieldPath: "widgets.0.box_and_whiskers_config.0.group_by",
+		},
+		{
+			name:      "geo map group_by",
+			root:      DashboardWidgetSchema["geo_map_config"],
+			keys:      []string{"group_by"},
+			fieldPath: "widgets.0.geo_map_config.0.group_by",
+		},
+		{
+			name:      "table row_group_by",
+			root:      DashboardWidgetSchema["table_config"],
+			keys:      []string{"row_group_by"},
+			fieldPath: "widgets.0.table_config.0.row_group_by",
+		},
+		{
+			name:      "table column_group_by",
+			root:      DashboardWidgetSchema["table_config"],
+			keys:      []string{"column_group_by"},
+			fieldPath: "widgets.0.table_config.0.column_group_by",
+		},
+		{
+			name:      "stacked bar axis_group_by",
+			root:      DashboardWidgetSchema["stacked_bar_chart_config"],
+			keys:      []string{"axis_group_by"},
+			fieldPath: "widgets.0.stacked_bar_chart_config.0.axis_group_by",
+		},
+		{
+			name:      "grouped bar group_by",
+			root:      DashboardWidgetSchema["grouped_bar_chart_config"],
+			keys:      []string{"group_by"},
+			fieldPath: "widgets.0.grouped_bar_chart_config.0.group_by",
+		},
+		{
+			name:      "grouped bar axis_group_by",
+			root:      DashboardWidgetSchema["grouped_bar_chart_config"],
+			keys:      []string{"axis_group_by"},
+			fieldPath: "widgets.0.grouped_bar_chart_config.0.axis_group_by",
+		},
+		{
+			name:      "multi metric table row_group_by",
+			root:      DashboardWidgetSchema["multi_metric_table_config"],
+			keys:      []string{"row_group_by"},
+			fieldPath: "widgets.0.multi_metric_table_config.0.row_group_by",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			propertySchema := getNestedSchemaProperty(t, testCase.root, testCase.keys...)
+			assertDashboardLabelValidation(t, propertySchema, testCase.fieldPath, "TEST", true)
+			assertDashboardLabelValidation(t, propertySchema, testCase.fieldPath, "AGENT", true)
+			assertDashboardLabelValidation(t, propertySchema, testCase.fieldPath, "TEST_LABEL", false)
+			assertDashboardLabelValidation(t, propertySchema, testCase.fieldPath, "AGENT_LABEL", false)
+			assertDashboardLabelValidation(t, propertySchema, testCase.fieldPath, "ENDPOINT_TEST_LABEL", false)
+		})
+	}
 }
 
 func getNestedSchemaProperty(t *testing.T, root *schema.Schema, keys ...string) *schema.Schema {
@@ -132,17 +219,17 @@ func getNestedSchemaProperty(t *testing.T, root *schema.Schema, keys ...string) 
 	return current
 }
 
-func assertDashboardFilterPropertyValidation(t *testing.T, propertySchema *schema.Schema, value string, valid bool) {
+func assertDashboardLabelValidation(t *testing.T, propertySchema *schema.Schema, path string, value string, valid bool) {
 	t.Helper()
 
 	require.NotNil(t, propertySchema.ValidateFunc)
 
-	_, errs := propertySchema.ValidateFunc(value, "widgets.0.filter.0.property")
+	_, errs := propertySchema.ValidateFunc(value, path)
 	if valid {
 		assert.Empty(t, errs)
 		return
 	}
 
 	require.NotEmpty(t, errs)
-	assert.ErrorContains(t, errs[0], "deprecated label filter property")
+	assert.ErrorContains(t, errs[0], "deprecated label value")
 }


### PR DESCRIPTION
## Summary
- rename dashboard label validation helper to a shared label validator
- apply deprecated label validation to dashboard group-by style schema fields (group_by, axis_group_by, row_group_by, column_group_by)
- extend schema tests with coverage for newly validated fields and update validation assertions to match current error wording
- bump thousandeyes SDK dependency to v3.0.0-alpha.20

## Testing
- go test ./thousandeyes/schemas -run DashboardWidgetSchema -count=1
- go test ./thousandeyes/schemas -count=1